### PR TITLE
Add monitoring property to Droplet

### DIFF
--- a/DigitalOcean.API/Models/Requests/Droplet.cs
+++ b/DigitalOcean.API/Models/Requests/Droplet.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DigitalOcean.API.Models.Requests {

--- a/DigitalOcean.API/Models/Requests/Droplet.cs
+++ b/DigitalOcean.API/Models/Requests/Droplet.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DigitalOcean.API.Models.Requests {
@@ -57,6 +57,12 @@ namespace DigitalOcean.API.Models.Requests {
         [JsonProperty("private_networking")]
         public bool PrivateNetworking { get; set; }
         
+        /// <summary>
+        /// A boolean indicating whether to install the DigitalOcean agent for monitoring.
+        /// </summary>
+        [JsonProperty("monitoring")]
+        public bool Monitoring { get; set; }
+
         /// <summary>
         /// A string containing a YAML formatted Cloud-Init script
         /// </summary>


### PR DESCRIPTION
I'm surprised this wasn't already in the library. I thought it was a rather older property in the API.

Pretty simple modification.

https://developers.digitalocean.com/documentation/v2/#create-a-new-droplet