### PR TITLE
Add CdnEndpoint and Certificate api calls

### DIFF
--- a/DigitalOcean.API.Tests/Clients/CdnEndpointsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/CdnEndpointsClientTest.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using DigitalOcean.API.Clients;
+using DigitalOcean.API.Http;
+using DigitalOcean.API.Models.Responses;
+using NSubstitute;
+using RestSharp;
+using Xunit;
+
+namespace DigitalOcean.API.Tests.Clients {
+    public class CdnEndpointsClientTest {
+        [Fact]
+        public void CorrectRequestForGetAll() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CdnEndpointsClient(factory);
+
+            client.GetAll();
+
+            factory.Received().GetPaginated<CdnEndpoint>("cdn/endpoints", null, "endpoints");
+        }
+
+        [Fact]
+        public void CorrectRequestForGet() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CdnEndpointsClient(factory);
+
+            client.Get("endpoint:abc123");
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "endpoint:abc123");
+            factory.Received().ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, null, "endpoint");
+        }
+
+        [Fact]
+        public void CorrectRequestForCreate() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CdnEndpointsClient(factory);
+
+            var body = new Models.Requests.CdnEndpoint();
+            client.Create(body);
+
+            factory.Received().ExecuteRequest<CdnEndpoint>("cdn/endpoints", null, body, "endpoint", Method.POST);
+        }
+
+        [Fact]
+        public void CorrectRequestForUpdate() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CdnEndpointsClient(factory);
+
+            var body = new Models.Requests.UpdateCdnEndpoint();
+            client.Update("endpoint:abc123", body);
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "endpoint:abc123");
+            factory.Received().ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, body, "endpoint", Method.PUT);
+        }
+
+        [Fact]
+        public void CorrectRequestForDelete() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CdnEndpointsClient(factory);
+
+            client.Delete("endpoint:abc123");
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "endpoint:abc123");
+            factory.Received().ExecuteRaw("cdn/endpoints/{endpoint_id}", parameters, null, Method.DELETE);
+        }
+
+        [Fact]
+        public void CorrectRequestForPurgeCache() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CdnEndpointsClient(factory);
+
+            var body = new Models.Requests.PurgeCdnFiles();
+            client.PurgeCache("endpoint:abc123", body);
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "endpoint:abc123");
+            factory.Received().ExecuteRaw("cdn/endpoints/{endpoint_id}/cache", parameters, body, Method.DELETE);
+        }
+    }
+}

--- a/DigitalOcean.API.Tests/Clients/CertificatesClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/CertificatesClientTest.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using DigitalOcean.API.Clients;
+using DigitalOcean.API.Http;
+using DigitalOcean.API.Models.Responses;
+using NSubstitute;
+using RestSharp;
+using Xunit;
+
+namespace DigitalOcean.API.Tests.Clients {
+    public class CertificatesClientTest {
+        [Fact]
+        public void CorrectRequestForGetAll() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CertificatesClient(factory);
+
+            client.GetAll();
+
+            factory.Received().GetPaginated<Certificate>("certificates", null, "certificates");
+        }
+
+        [Fact]
+        public void CorrectRequestForGet() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CertificatesClient(factory);
+
+            client.Get("certificate:abc123");
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "certificate:abc123");
+            factory.Received().ExecuteRequest<Certificate>("certificates/{certificate_id}", parameters, null, "certificate");
+        }
+
+        [Fact]
+        public void CorrectRequestForCreate() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CertificatesClient(factory);
+
+            var body = new Models.Requests.Certificate();
+            client.Create(body);
+
+            factory.Received().ExecuteRequest<Certificate>("certificates", null, body, "certificate", Method.POST);
+        }
+
+        [Fact]
+        public void CorrectRequestForDelete() {
+            var factory = Substitute.For<IConnection>();
+            var client = new CertificatesClient(factory);
+
+            client.Delete("certificate:abc123");
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "certificate:abc123");
+            factory.Received().ExecuteRaw("certificates/{certificate_id}", parameters, null, Method.DELETE);
+        }
+    }
+}

--- a/DigitalOcean.API/Clients/CdnEndpointsClient.cs
+++ b/DigitalOcean.API/Clients/CdnEndpointsClient.cs
@@ -40,22 +40,10 @@ namespace DigitalOcean.API.Clients {
         /// <summary>
         /// To update the TTL, certificate ID, or the FQDN of the custom subdomain for an existing CDN endpoint.
         /// </summary>
-        public Task<CdnEndpoint> Update(string endpointId, int? ttl = null, string certificateId = null, string customDomain = null) {
+        public Task<CdnEndpoint> Update(string endpointId, Models.Requests.UpdateCdnEndpoint updateEndpoint) {
             var parameters = new List<Parameter> {
                 new Parameter { Name = "endpoint_id", Value = endpointId, Type = ParameterType.UrlSegment }
             };
-            var updateEndpoint = new Dictionary<string, object>(3);
-            if (ttl.HasValue) {
-                updateEndpoint["ttl"] = ttl.Value;
-            }
-            // allow empty string to pass through
-            // test unsetting these
-            if (certificateId != null) {
-                updateEndpoint["certificate_id"] = certificateId;
-            }
-            if (customDomain != null) {
-                updateEndpoint["custom_domain"] = customDomain;
-            }
             return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, updateEndpoint, "endpoint", Method.PUT);
         }
 
@@ -74,12 +62,9 @@ namespace DigitalOcean.API.Clients {
         /// A path may be for a single file or may contain a wildcard (*) to recursively purge all files under a directory.
         /// When only a wildcard is provided, all cached files will be purged.
         /// </summary>
-        public Task PurgeCache(string endpointId, List<string> files) {
+        public Task PurgeCache(string endpointId, Models.Requests.PurgeCdnFiles purgeFiles) {
             var parameters = new List<Parameter> {
                 new Parameter { Name = "endpoint_id", Value = endpointId, Type = ParameterType.UrlSegment }
-            };
-            var purgeFiles = new {
-                files = files
             };
             return _connection.ExecuteRaw("cdn/endpoints/{endpoint_id}/cache", parameters, purgeFiles, Method.DELETE);
         }

--- a/DigitalOcean.API/Clients/CdnEndpointsClient.cs
+++ b/DigitalOcean.API/Clients/CdnEndpointsClient.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using DigitalOcean.API.Http;
+using DigitalOcean.API.Models.Responses;
+using RestSharp;
+
+namespace DigitalOcean.API.Clients {
+    public class CdnEndpointsClient : ICdnEndpointsClient {
+        private readonly IConnection _connection;
+
+        public CdnEndpointsClient(IConnection connection) {
+            _connection = connection;
+        }
+
+        /// <summary>
+        /// To list all of the CDN endpoints available on your account.
+        /// </summary>
+        public Task<IReadOnlyList<CdnEndpoint>> GetAll() {
+            return _connection.GetPaginated<CdnEndpoint>("cdn/endpoints", null, "endpoints");
+        }
+
+        /// <summary>
+        /// To show information about an existing CDN endpoint.
+        /// </summary>
+        public Task<CdnEndpoint> Get(string endpointId) {
+            var parameters = new List<Parameter> {
+                new Parameter { Name = "endpoint_id", Value = endpointId, Type = ParameterType.UrlSegment }
+            };
+            return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, null, "endpoint");
+        }
+
+        /// <summary>
+        /// To create a new CDN endpoint.
+        /// The Origin attribute must be set to the fully qualified domain name (FQDN) of a DigitalOcean Space.
+        /// </summary>
+        public Task<CdnEndpoint> Create(Models.Requests.CdnEndpoint endpoint) {
+            return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints", null, endpoint, "endpoint", Method.POST);
+        }
+
+        /// <summary>
+        /// To update the TTL, certificate ID, or the FQDN of the custom subdomain for an existing CDN endpoint.
+        /// </summary>
+        public Task<CdnEndpoint> Update(string endpointId, int? ttl = null, string certificateId = null, string customDomain = null) {
+            var parameters = new List<Parameter> {
+                new Parameter { Name = "endpoint_id", Value = endpointId, Type = ParameterType.UrlSegment }
+            };
+            var updateEndpoint = new Dictionary<string, object>(3);
+            if (ttl.HasValue) {
+                updateEndpoint["ttl"] = ttl.Value;
+            }
+            // allow empty string to pass through
+            // test unsetting these
+            if (certificateId != null) {
+                updateEndpoint["certificate_id"] = certificateId;
+            }
+            if (customDomain != null) {
+                updateEndpoint["custom_domain"] = customDomain;
+            }
+            return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, updateEndpoint, "endpoint", Method.PUT);
+        }
+
+        /// <summary>
+        /// To delete a specific CDN endpoint.
+        /// </summary>
+        public Task Delete(string endpointId) {
+            var parameters = new List<Parameter> {
+                new Parameter { Name = "endpoint_id", Value = endpointId, Type = ParameterType.UrlSegment }
+            };
+            return _connection.ExecuteRaw("cdn/endpoints/{endpoint_id}", parameters, null, Method.DELETE);
+        }
+
+        /// <summary>
+        /// To purge cached content from a CDN endpoint.
+        /// A path may be for a single file or may contain a wildcard (*) to recursively purge all files under a directory.
+        /// When only a wildcard is provided, all cached files will be purged.
+        /// </summary>
+        public Task PurgeCache(string endpointId, List<string> files) {
+            var parameters = new List<Parameter> {
+                new Parameter { Name = "endpoint_id", Value = endpointId, Type = ParameterType.UrlSegment }
+            };
+            var purgeFiles = new {
+                files = files
+            };
+            return _connection.ExecuteRaw("cdn/endpoints/{endpoint_id}/cache", parameters, purgeFiles, Method.DELETE);
+        }
+    }
+}

--- a/DigitalOcean.API/Clients/CertificatesClient.cs
+++ b/DigitalOcean.API/Clients/CertificatesClient.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using DigitalOcean.API.Http;
+using DigitalOcean.API.Models.Responses;
+using RestSharp;
+
+namespace DigitalOcean.API.Clients {
+    public class CertificatesClient : ICertificatesClient {
+        private readonly IConnection _connection;
+
+        public CertificatesClient(IConnection connection) {
+            _connection = connection;
+        }
+
+        /// <summary>
+        /// To list all of the certificates available on your account.
+        /// </summary>
+        public Task<IReadOnlyList<Certificate>> GetAll() {
+            return _connection.GetPaginated<Certificate>("certificates", null, "certificates");
+        }
+
+        /// <summary>
+        /// To show information about an existing certificate.
+        /// </summary>
+        public Task<Certificate> Get(string certificateId) {
+            var parameters = new List<Parameter> {
+                new Parameter { Name = "certificate_id", Value = certificateId, Type = ParameterType.UrlSegment }
+            };
+            return _connection.ExecuteRequest<Certificate>("certificates/{certificate_id}", parameters, null, "certificate");
+        }
+
+        /// <summary>
+        /// Create a new Let's Encrypt Certificate:
+        /// When using Let's Encrypt to create a certificate, the dns_names attribute must be provided,
+        /// and the type must be set to "lets_encrypt".
+        ///
+        /// Create a new custom Certificate:
+        /// When uploading a user-generated certificate, the private_key, leaf_certificate, and optionally the certificate_chain
+        /// attributes should be provided. The type must be set to "custom".
+        /// </summary>
+        public Task<Certificate> Create(Models.Requests.Certificate certificate) {
+            return _connection.ExecuteRequest<Certificate>("certificates", null, certificate, "certificate", Method.POST);
+        }
+
+        /// <summary>
+        /// To delete a specific certificate.
+        /// </summary>
+        public Task Delete(string certificateId) {
+            var parameters = new List<Parameter> {
+                new Parameter { Name = "certificate_id", Value = certificateId, Type = ParameterType.UrlSegment }
+            };
+            return _connection.ExecuteRaw("certificates/{certificate_id}", parameters, null, Method.DELETE);
+        }
+    }
+}

--- a/DigitalOcean.API/Clients/ICdnEndpointsClient.cs
+++ b/DigitalOcean.API/Clients/ICdnEndpointsClient.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using DigitalOcean.API.Models.Responses;
+
+namespace DigitalOcean.API.Clients {
+    public interface ICdnEndpointsClient {
+        /// <summary>
+        /// To list all of the CDN endpoints available on your account.
+        /// </summary>
+        Task<IReadOnlyList<CdnEndpoint>> GetAll();
+
+        /// <summary>
+        /// To show information about an existing CDN endpoint.
+        /// </summary>
+        Task<CdnEndpoint> Get(string endpointId);
+
+        /// <summary>
+        /// To create a new CDN endpoint.
+        /// The Origin attribute must be set to the fully qualified domain name (FQDN) of a DigitalOcean Space.
+        /// </summary>
+        Task<CdnEndpoint> Create(Models.Requests.CdnEndpoint endpoint);
+
+        /// <summary>
+        /// To update the TTL, certificate ID, or the FQDN of the custom subdomain for an existing CDN endpoint.
+        /// </summary>
+        Task<CdnEndpoint> Update(string endpointId, int? ttl = null, string certificateId = null, string customDomain = null);
+
+        /// <summary>
+        /// To delete a specific CDN endpoint.
+        /// </summary>
+        Task Delete(string endpointId);
+
+        /// <summary>
+        /// To purge cached content from a CDN endpoint.
+        /// A path may be for a single file or may contain a wildcard (*) to recursively purge all files under a directory.
+        /// When only a wildcard is provided, all cached files will be purged.
+        /// </summary>
+        Task PurgeCache(string endpointId, List<string> files);
+    }
+}

--- a/DigitalOcean.API/Clients/ICdnEndpointsClient.cs
+++ b/DigitalOcean.API/Clients/ICdnEndpointsClient.cs
@@ -23,7 +23,7 @@ namespace DigitalOcean.API.Clients {
         /// <summary>
         /// To update the TTL, certificate ID, or the FQDN of the custom subdomain for an existing CDN endpoint.
         /// </summary>
-        Task<CdnEndpoint> Update(string endpointId, int? ttl = null, string certificateId = null, string customDomain = null);
+        Task<CdnEndpoint> Update(string endpointId, Models.Requests.UpdateCdnEndpoint updateEndpoint);
 
         /// <summary>
         /// To delete a specific CDN endpoint.
@@ -35,6 +35,6 @@ namespace DigitalOcean.API.Clients {
         /// A path may be for a single file or may contain a wildcard (*) to recursively purge all files under a directory.
         /// When only a wildcard is provided, all cached files will be purged.
         /// </summary>
-        Task PurgeCache(string endpointId, List<string> files);
+        Task PurgeCache(string endpointId, Models.Requests.PurgeCdnFiles purgeFiles);
     }
 }

--- a/DigitalOcean.API/Clients/ICertificatesClient.cs
+++ b/DigitalOcean.API/Clients/ICertificatesClient.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using DigitalOcean.API.Models.Responses;
+
+namespace DigitalOcean.API.Clients {
+    public interface ICertificatesClient {
+        /// <summary>
+        /// To list all of the certificates available on your account.
+        /// </summary>
+        Task<IReadOnlyList<Certificate>> GetAll();
+
+        /// <summary>
+        /// To show information about an existing certificate.
+        /// </summary>
+        Task<Certificate> Get(string certificateId);
+
+        /// <summary>
+        /// Create a new Let's Encrypt Certificate:
+        /// When using Let's Encrypt to create a certificate, the dns_names attribute must be provided,
+        /// and the type must be set to "lets_encrypt".
+        ///
+        /// Create a new custom Certificate:
+        /// When uploading a user-generated certificate, the private_key, leaf_certificate, and optionally the certificate_chain
+        /// attributes should be provided. The type must be set to "custom".
+        /// </summary>
+        Task<Certificate> Create(Models.Requests.Certificate certificate);
+
+        /// <summary>
+        /// To delete a specific certificate.
+        /// </summary>
+        Task Delete(string certificateId);
+    }
+}

--- a/DigitalOcean.API/DigitalOceanClient.cs
+++ b/DigitalOcean.API/DigitalOceanClient.cs
@@ -17,6 +17,7 @@ namespace DigitalOcean.API {
 
             Actions = new ActionsClient(_connection);
             CdnEndpoints = new CdnEndpointsClient(_connection);
+            Certificates = new CertificatesClient(_connection);
             DomainRecords = new DomainRecordsClient(_connection);
             Domains = new DomainsClient(_connection);
             DropletActions = new DropletActionsClient(_connection);
@@ -38,6 +39,7 @@ namespace DigitalOcean.API {
 
         public IActionsClient Actions { get; private set; }
         public ICdnEndpointsClient CdnEndpoints { get; private set; }
+        public ICertificatesClient Certificates { get; private set; }
         public IDomainRecordsClient DomainRecords { get; private set; }
         public IDomainsClient Domains { get; private set; }
         public IDropletActionsClient DropletActions { get; private set; }

--- a/DigitalOcean.API/DigitalOceanClient.cs
+++ b/DigitalOcean.API/DigitalOceanClient.cs
@@ -16,6 +16,7 @@ namespace DigitalOcean.API {
             _connection = new Connection(client);
 
             Actions = new ActionsClient(_connection);
+            CdnEndpoints = new CdnEndpointsClient(_connection);
             DomainRecords = new DomainRecordsClient(_connection);
             Domains = new DomainsClient(_connection);
             DropletActions = new DropletActionsClient(_connection);
@@ -36,6 +37,7 @@ namespace DigitalOcean.API {
         }
 
         public IActionsClient Actions { get; private set; }
+        public ICdnEndpointsClient CdnEndpoints { get; private set; }
         public IDomainRecordsClient DomainRecords { get; private set; }
         public IDomainsClient Domains { get; private set; }
         public IDropletActionsClient DropletActions { get; private set; }

--- a/DigitalOcean.API/IDigitalOceanClient.cs
+++ b/DigitalOcean.API/IDigitalOceanClient.cs
@@ -5,6 +5,7 @@ namespace DigitalOcean.API {
     public interface IDigitalOceanClient {
         IActionsClient Actions { get; }
         ICdnEndpointsClient CdnEndpoints { get; }
+        ICertificatesClient Certificates { get; }
         IDomainRecordsClient DomainRecords { get; }
         IDomainsClient Domains { get; }
         IDropletActionsClient DropletActions { get; }

--- a/DigitalOcean.API/IDigitalOceanClient.cs
+++ b/DigitalOcean.API/IDigitalOceanClient.cs
@@ -4,6 +4,7 @@ using DigitalOcean.API.Http;
 namespace DigitalOcean.API {
     public interface IDigitalOceanClient {
         IActionsClient Actions { get; }
+        ICdnEndpointsClient CdnEndpoints { get; }
         IDomainRecordsClient DomainRecords { get; }
         IDomainsClient Domains { get; }
         IDropletActionsClient DropletActions { get; }

--- a/DigitalOcean.API/Models/Requests/CdnEndpoint.cs
+++ b/DigitalOcean.API/Models/Requests/CdnEndpoint.cs
@@ -13,7 +13,7 @@ namespace DigitalOcean.API.Models.Requests {
         /// The amount of time the content is cached by the CDN's edge servers in seconds. Defaults to 3600 (one hour) when excluded.
         /// </summary>
         [JsonProperty("ttl")]
-        public int? TTL { get; set; }
+        public int? Ttl { get; set; }
 
         /// <summary>
         /// The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.

--- a/DigitalOcean.API/Models/Requests/CdnEndpoint.cs
+++ b/DigitalOcean.API/Models/Requests/CdnEndpoint.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Requests {
+    public class CdnEndpoint {
+        /// <summary>
+        /// The fully qualified domain name (FQDN) for the origin server which the provides the content for the CDN. This is currently
+        /// restricted to a Space.
+        /// </summary>
+        [JsonProperty("origin")]
+        public string Origin { get; set; }
+
+        /// <summary>
+        /// The amount of time the content is cached by the CDN's edge servers in seconds. Defaults to 3600 (one hour) when excluded.
+        /// </summary>
+        [JsonProperty("ttl")]
+        public int? TTL { get; set; }
+
+        /// <summary>
+        /// The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
+        /// </summary>
+        [JsonProperty("certificate_id")]
+        public string CertificateId { get; set; }
+
+        /// <summary>
+        /// The fully qualified domain name (FQDN) of the custom subdomain to be used with the CDN Endpoint. When used, a certificate_id
+        /// must be provided as well.
+        /// </summary>
+        [JsonProperty("custom_domain")]
+        public string CustomDomain { get; set; }
+    }
+}

--- a/DigitalOcean.API/Models/Requests/Certificate.cs
+++ b/DigitalOcean.API/Models/Requests/Certificate.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Requests {
+    public class Certificate {
+        /// <summary>
+        /// A unique human-readable name referring to a certificate.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A string representing the type of the certificate. The value should be "custom" for a user-uploaded certificate or
+        /// "lets_encrypt" for one automatically generated with Let's Encrypt.
+        /// If not provided, "custom" will be assumed by default.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// An array of fully qualified domain names (FQDNs) for which the certificate will be issued.
+        /// The domains must be managed using DigitalOcean's DNS.
+        /// </summary>
+        [JsonProperty("dns_names")]
+        public List<string> DnsNames { get; set; }
+
+        /// <summary>
+        /// The contents of a PEM-formatted private-key corresponding to the SSL certificate.
+        /// </summary>
+        [JsonProperty("private_key")]
+        public string PrivateKey { get; set; }
+
+        /// <summary>
+        /// The contents of a PEM-formatted public SSL certificate.
+        /// </summary>
+        [JsonProperty("leaf_certificate")]
+        public string LeafCertificate { get; set; }
+
+        /// <summary>
+        /// The full PEM-formatted trust chain between the certificate authority's certificate and your domain's SSL certificate.
+        /// </summary>
+        [JsonProperty("certificate_chain")]
+        public string CertificateChain { get; set; }
+    }
+}

--- a/DigitalOcean.API/Models/Requests/PurgeCdnFiles.cs
+++ b/DigitalOcean.API/Models/Requests/PurgeCdnFiles.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Requests {
+    public class PurgeCdnFiles {
+        /// <summary>
+        /// An array of strings containing the path to the content to be purged from the CDN cache.
+        /// </summary>
+        [JsonProperty("files")]
+        public List<string> Files { get; set; }
+    }
+}

--- a/DigitalOcean.API/Models/Requests/UpdateCdnEndpoint.cs
+++ b/DigitalOcean.API/Models/Requests/UpdateCdnEndpoint.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace DigitalOcean.API.Models.Requests {
     public class UpdateCdnEndpoint {
@@ -10,6 +10,7 @@ namespace DigitalOcean.API.Models.Requests {
 
         /// <summary>
         /// The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
+        /// In order to remove value, set to empty string.
         /// </summary>
         [JsonProperty("certificate_id")]
         public string CertificateId { get; set; }
@@ -17,6 +18,7 @@ namespace DigitalOcean.API.Models.Requests {
         /// <summary>
         /// The fully qualified domain name (FQDN) of the custom subdomain to be used with the CDN Endpoint. When used, a certificate_id
         /// must be provided as well.
+        /// In order to remove value, set to empty string.
         /// </summary>
         [JsonProperty("custom_domain")]
         public string CustomDomain { get; set; }

--- a/DigitalOcean.API/Models/Requests/UpdateCdnEndpoint.cs
+++ b/DigitalOcean.API/Models/Requests/UpdateCdnEndpoint.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Requests {
+    public class UpdateCdnEndpoint {
+        /// <summary>
+        /// The amount of time the content is cached by the CDN's edge servers in seconds.
+        /// </summary>
+        [JsonProperty("ttl")]
+        public int? TTL { get; set; }
+
+        /// <summary>
+        /// The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
+        /// </summary>
+        [JsonProperty("certificate_id")]
+        public string CertificateId { get; set; }
+
+        /// <summary>
+        /// The fully qualified domain name (FQDN) of the custom subdomain to be used with the CDN Endpoint. When used, a certificate_id
+        /// must be provided as well.
+        /// </summary>
+        [JsonProperty("custom_domain")]
+        public string CustomDomain { get; set; }
+    }
+}

--- a/DigitalOcean.API/Models/Responses/CdnEndpoint.cs
+++ b/DigitalOcean.API/Models/Responses/CdnEndpoint.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace DigitalOcean.API.Models.Responses {
+    public class CdnEndpoint {
+        /// <summary>
+        /// A unique ID that can be used to identify and reference a CDN endpoint.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The fully qualified domain name (FQDN) for the origin server which the provides the content for the CDN.
+        /// This is currently restricted to a Space.
+        /// </summary>
+        public string Origin { get; set; }
+
+        /// <summary>
+        /// The fully qualified domain name (FQDN) from which the CDN-backed content is served.
+        /// </summary>
+        public string Endpoint { get; set; }
+
+        /// <summary>
+        /// A time value given in ISO8601 combined date and time format that represents when the CDN endpoint was created.
+        /// </summary>
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// The amount of time the content is cached by the CDN's edge servers in seconds.
+        /// </summary>
+        public int TTL { get; set; }
+
+        /// <summary>
+        /// The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.
+        /// </summary>
+        public string CertificateId { get; set; }
+
+        /// <summary>
+        /// The fully qualified domain name (FQDN) of the custom subdomain used with the CDN Endpoint.
+        /// </summary>
+        public string CustomDomain { get; set; }
+    }
+}

--- a/DigitalOcean.API/Models/Responses/CdnEndpoint.cs
+++ b/DigitalOcean.API/Models/Responses/CdnEndpoint.cs
@@ -26,7 +26,7 @@ namespace DigitalOcean.API.Models.Responses {
         /// <summary>
         /// The amount of time the content is cached by the CDN's edge servers in seconds.
         /// </summary>
-        public int TTL { get; set; }
+        public int Ttl { get; set; }
 
         /// <summary>
         /// The ID of a DigitalOcean managed TLS certificate used for SSL when a custom subdomain is provided.

--- a/DigitalOcean.API/Models/Responses/Certificate.cs
+++ b/DigitalOcean.API/Models/Responses/Certificate.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DigitalOcean.API.Models.Responses {
+    public class Certificate {
+        /// <summary>
+        /// A unique ID that can be used to identify and reference a certificate.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// A unique human-readable name referring to a certificate.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A time value given in ISO8601 combined date and time format that represents the certificate's expiration date.
+        /// </summary>
+        public DateTime NotAfter { get; set; }
+
+        /// <summary>
+        /// A unique identifier generated from the SHA-1 fingerprint of the certificate.
+        /// </summary>
+        public string Sha1Fingerprint { get; set; }
+
+        /// <summary>
+        /// A time value given in ISO8601 combined date and time format that represents when the certificate was created.
+        /// </summary>
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// An array of fully qualified domain names (FQDNs) for which the certificate was issued.
+        /// </summary>
+        public List<string> DnsNames { get; set; }
+
+        /// <summary>
+        /// A string representing the current state of the certificate. It may be "pending", "verified", or "error".
+        /// </summary>
+        public string State { get; set; }
+
+        /// <summary>
+        /// A string representing the type of the certificate. The value will be "custom" for a user-uploaded certificate or
+        /// "lets_encrypt" for one automatically generated with Let's Encrypt.
+        /// </summary>
+        public string Type { get; set; }
+    }
+}


### PR DESCRIPTION
Fully implemented [CdnEndpoints](https://developers.digitalocean.com/documentation/v2/#cdn-endpoints) and [Certificates](https://developers.digitalocean.com/documentation/v2/#certificates) APIs. Certificates potentially usable in cdn endpoints, why I included both together here.

Continued following same style as last time. All tests included as well.
Tested all calls myself against actual API as well.