### PR TITLE
FloatingIp Final Nullable fix

### DIFF
--- a/DigitalOcean.API/Models/Requests/FloatingIp.cs
+++ b/DigitalOcean.API/Models/Requests/FloatingIp.cs
@@ -4,12 +4,14 @@ namespace DigitalOcean.API.Models.Requests {
     public class FloatingIp {
         /// <summary>
         /// The ID of Droplet that the Floating IP will be assigned to.
+        /// This attribute and the "region" attribute are mutually exclusive.
         /// </summary>
         [JsonProperty("droplet_id")]
-        public int DropletId { get; set; }
+        public int? DropletId { get; set; }
 
         /// <summary>
         /// The slug identifier for the region the Floating IP will be reserved to.
+        /// This attribute and the "droplet_id" attribute are mutually exclusive.
         /// </summary>
         [JsonProperty("region")]
         public string Region { get; set; }


### PR DESCRIPTION
DropletId should be marked nullable in `Models.Requests.FloatingIp`, with extra doc notes that the two properties in it are mutually exclusive.