### PR TITLE
Fix Addresses property name

### DIFF
--- a/DigitalOcean.API/Models/Requests/SourceLocation.cs
+++ b/DigitalOcean.API/Models/Requests/SourceLocation.cs
@@ -7,7 +7,7 @@ namespace DigitalOcean.API.Models.Requests {
         /// An array of strings containing the IPv4 addresses, IPv6 addresses, IPv4 CIDRs, and/or IPv6 CIDRs to which the Firewall will allow traffic.
         /// </summary>
         [JsonProperty("addresses")]
-        public List<string> Addressess { get; set; }
+        public List<string> Addresses { get; set; }
 
         /// <summary>
         /// An array containing the IDs of the Droplets to which the Firewall will allow traffic.

--- a/DigitalOcean.API/Models/Responses/SourceLocation.cs
+++ b/DigitalOcean.API/Models/Responses/SourceLocation.cs
@@ -6,7 +6,7 @@ namespace DigitalOcean.API.Models.Responses {
         /// <summary>
         /// An array of strings containing the IPv4 addresses, IPv6 addresses, IPv4 CIDRs, and/or IPv6 CIDRs to which the Firewall will allow traffic.
         /// </summary>
-        public List<string> Addressess { get; set; }
+        public List<string> Addresses { get; set; }
 
         /// <summary>
         /// An array containing the IDs of the Droplets to which the Firewall will allow traffic.


### PR DESCRIPTION
In the SourceLocation class, I noticed an error in address deserialization. There was an extra letter at the end of the word. Because of this, the property is always equal null.