### PR TITLE
Fix header names for rate limiting

### DIFF
--- a/DigitalOcean.API/Http/RateLimit.cs
+++ b/DigitalOcean.API/Http/RateLimit.cs
@@ -5,9 +5,9 @@ using RestSharp;
 namespace DigitalOcean.API.Http {
     public class RateLimit : IRateLimit {
         public RateLimit(IList<Parameter> headers) {
-            Limit = GetHeaderValue(headers, "RateLimit-Limit");
-            Remaining = GetHeaderValue(headers, "RateLimit-Remaining");
-            Reset = GetHeaderValue(headers, "RateLimit-Reset");
+            Limit = GetHeaderValue(headers, "Ratelimit-Limit");
+            Remaining = GetHeaderValue(headers, "Ratelimit-Remaining");
+            Reset = GetHeaderValue(headers, "Ratelimit-Reset");
         }
 
         #region IRateLimit Members


### PR DESCRIPTION
Although the docs [here](https://developers.digitalocean.com/documentation/v2/#rate-limit) show L in RateLimit parameters uppercase, the API actually returns lower case. This causes all values to be 0. I tested this using Postman and [here](https://i.imgur.com/cu4Ihvj.png) are response headers.