### PR TITLE
New VPC Endpoint in API

### DIFF
--- a/DigitalOcean.API.Tests/Clients/VpcClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/VpcClientTest.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using DigitalOcean.API.Clients;
+using DigitalOcean.API.Http;
+using DigitalOcean.API.Models.Responses;
+using NSubstitute;
+using RestSharp;
+using Xunit;
+
+namespace DigitalOcean.API.Tests.Clients {
+    public class VpcClientTest {
+        [Fact]
+        public void CorrectRequestForGetAll() {
+            var factory = Substitute.For<IConnection>();
+            var client = new VpcClient(factory);
+
+            client.GetAll();
+
+            factory.Received().GetPaginated<Vpc>("vpcs", null, "vpcs");
+        }
+
+        [Fact]
+        public void CorrectRequestForCreate() {
+            var factory = Substitute.For<IConnection>();
+            var client = new VpcClient(factory);
+
+            var body = new Models.Requests.Vpc();
+            client.Create(body);
+
+            factory.Received().ExecuteRequest<Vpc>("vpcs", null, body, "vpc", Method.POST);
+        }
+
+        [Fact]
+        public void CorrectRequestForGet() {
+            var factory = Substitute.For<IConnection>();
+            var client = new VpcClient(factory);
+
+            client.Get("abcdefg");
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "abcdefg");
+            factory.Received().ExecuteRequest<Vpc>("vpcs/{id}", parameters, null, "vpc");
+        }
+
+        [Fact]
+        public void CorrectRequestForDelete() {
+            var factory = Substitute.For<IConnection>();
+            var client = new VpcClient(factory);
+
+            client.Delete("abcdefg");
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "abcdefg");
+            factory.Received().ExecuteRaw("vpcs/{id}", parameters, null, Method.DELETE);
+        }
+
+        [Fact]
+        public void CorrectRequestForUpdate() {
+            var factory = Substitute.For<IConnection>();
+            var client = new VpcClient(factory);
+
+            var body = new Models.Requests.UpdateVpc();
+            client.Update("abcdefg", body);
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "abcdefg");
+            factory.Received().ExecuteRequest<Vpc>("vpcs/{id}", parameters, body, "vpc", Method.PUT);
+        }
+
+        [Fact]
+        public void CorrectRequestForPartialUpdate() {
+            var factory = Substitute.For<IConnection>();
+            var client = new VpcClient(factory);
+
+            var body = new Models.Requests.UpdateVpc();
+            client.PartialUpdate("abcdefg", body);
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "abcdefg");
+            factory.Received().ExecuteRequest<Vpc>("vpcs/{id}", parameters, body, "vpc", Method.PATCH);
+        }
+
+        [Fact]
+        public void CorrectRequestForListMembers() {
+            var factory = Substitute.For<IConnection>();
+            var client = new VpcClient(factory);
+
+            client.ListMembers("abcdefg");
+
+            var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "abcdefg");
+            factory.Received().GetPaginated<VpcMember>("vpcs/{id}/members", parameters, "members");
+        }
+    }
+}

--- a/DigitalOcean.API/Clients/IDropletActionsClient.cs
+++ b/DigitalOcean.API/Clients/IDropletActionsClient.cs
@@ -78,6 +78,7 @@ namespace DigitalOcean.API.Clients {
 
         /// <summary>
         /// Enable private networking on a droplet
+        /// When VPC is enabled on your account, this will add the Droplet to your account's default VPC for the region.
         /// </summary>
         Task<Action> EnablePrivateNetworking(long dropletId);
 

--- a/DigitalOcean.API/Clients/IVpcClient.cs
+++ b/DigitalOcean.API/Clients/IVpcClient.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DigitalOcean.API.Models.Responses;
+
+namespace DigitalOcean.API.Clients {
+    public interface IVpcClient {
+        /// <summary>
+        /// To list all of the VPCs on your account.
+        /// </summary>
+        Task<IReadOnlyList<Vpc>> GetAll();
+
+        /// <summary>
+        /// To create a VPC.
+        /// </summary>
+        Task<Vpc> Create(Models.Requests.Vpc vpc);
+
+        /// <summary>
+        /// To show information about an existing VPC.
+        /// </summary>
+        Task<Vpc> Get(string vpcId);
+
+        /// <summary>
+        /// To delete a VPC.
+        /// The default VPC for a region can not be deleted.
+        /// Additionally, a VPC can only be deleted if it does not contain any member resources.
+        /// Attempting to delete a region's default VPC or a VPC that still has members will result in an error response.
+        /// </summary>
+        Task Delete(string vpcId);
+
+        /// <summary>
+        /// To update information about a VPC.
+        /// Currently, only the name and description attributes can be updated.
+        /// Excluding an attribute will reset it to its default.
+        /// </summary>
+        Task<Vpc> Update(string vpcId, Models.Requests.UpdateVpc updateVpc);
+
+        /// <summary>
+        /// To update a subset of information about a VPC.
+        /// Currently, only the name and description attributes can be updated.
+        /// </summary>
+        Task<Vpc> PartialUpdate(string vpcId, Models.Requests.UpdateVpc updateVpc);
+
+        /// <summary>
+        /// To list all of the resources that are members of a VPC.
+        /// To only list resources of a specific type that are members of the VPC, included a resource_type query parameter.
+        /// </summary>
+        Task<IReadOnlyList<VpcMember>> ListMembers(string vpcId, string resourceType = null);
+    }
+}

--- a/DigitalOcean.API/Clients/VpcClient.cs
+++ b/DigitalOcean.API/Clients/VpcClient.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DigitalOcean.API.Http;
+using DigitalOcean.API.Models.Responses;
+using RestSharp;
+
+namespace DigitalOcean.API.Clients {
+    public class VpcClient : IVpcClient {
+        private readonly IConnection _connection;
+
+        public VpcClient(IConnection connection) {
+            _connection = connection;
+        }
+
+        /// <summary>
+        /// To list all of the VPCs on your account.
+        /// </summary>
+        public Task<IReadOnlyList<Vpc>> GetAll() {
+            return _connection.GetPaginated<Vpc>("vpcs", null, "vpcs");
+        }
+
+        /// <summary>
+        /// To create a VPC.
+        /// </summary>
+        public Task<Vpc> Create(Models.Requests.Vpc vpc) {
+            return _connection.ExecuteRequest<Vpc>("vpcs", null, vpc, "vpc", Method.POST);
+        }
+
+        /// <summary>
+        /// To show information about an existing VPC.
+        /// </summary>
+        public Task<Vpc> Get(string vpcId) {
+            var parameters = new List<Parameter> {
+                new Parameter("id", vpcId, ParameterType.UrlSegment)
+            };
+            return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, null, "vpc");
+        }
+
+        /// <summary>
+        /// To delete a VPC.
+        /// The default VPC for a region can not be deleted.
+        /// Additionally, a VPC can only be deleted if it does not contain any member resources.
+        /// Attempting to delete a region's default VPC or a VPC that still has members will result in an error response.
+        /// </summary>
+        public Task Delete(string vpcId) {
+            var parameters = new List<Parameter> {
+                new Parameter("id", vpcId, ParameterType.UrlSegment)
+            };
+            return _connection.ExecuteRaw("vpcs/{id}", parameters, null, Method.DELETE);
+        }
+
+        /// <summary>
+        /// To update information about a VPC.
+        /// Currently, only the name and description attributes can be updated.
+        /// Excluding an attribute will reset it to its default.
+        /// </summary>
+        public Task<Vpc> Update(string vpcId, Models.Requests.UpdateVpc updateVpc) {
+            var parameters = new List<Parameter> {
+                new Parameter("id", vpcId, ParameterType.UrlSegment)
+            };
+            return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, updateVpc, "vpc", Method.PUT);
+        }
+
+        /// <summary>
+        /// To update a subset of information about a VPC.
+        /// Currently, only the name and description attributes can be updated.
+        /// </summary>
+        public Task<Vpc> PartialUpdate(string vpcId, Models.Requests.UpdateVpc updateVpc) {
+            var parameters = new List<Parameter> {
+                new Parameter("id", vpcId, ParameterType.UrlSegment)
+            };
+            return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, updateVpc, "vpc", Method.PATCH);
+        }
+
+        /// <summary>
+        /// To list all of the resources that are members of a VPC.
+        /// To only list resources of a specific type that are members of the VPC, included a resource_type query parameter.
+        /// </summary>
+        public Task<IReadOnlyList<VpcMember>> ListMembers(string vpcId, string resourceType = null) {
+            var parameters = new List<Parameter> {
+                new Parameter("id", vpcId, ParameterType.UrlSegment)
+            };
+            if (!String.IsNullOrEmpty(resourceType)) {
+                parameters.Add(new Parameter("resource_type", resourceType, ParameterType.QueryString));
+            }
+            return _connection.GetPaginated<VpcMember>("vpcs/{id}/members", parameters, "members");
+        }
+    }
+}

--- a/DigitalOcean.API/DigitalOceanClient.cs
+++ b/DigitalOcean.API/DigitalOceanClient.cs
@@ -41,6 +41,7 @@ namespace DigitalOcean.API {
             Volumes = new VolumesClient(_connection);
             VolumeActions = new VolumeActionsClient(_connection);
             BalanceClient = new BalanceClient(_connection);
+            Vpc = new VpcClient(_connection);
         }
 
         #region IDigitalOceanClient Members
@@ -75,6 +76,7 @@ namespace DigitalOcean.API {
         public IVolumesClient Volumes { get; private set; }
         public IVolumeActionsClient VolumeActions { get; private set; }
         public IBalanceClient BalanceClient { get; private set; }
+        public IVpcClient Vpc { get; private set; }
 
         #endregion
     }

--- a/DigitalOcean.API/IDigitalOceanClient.cs
+++ b/DigitalOcean.API/IDigitalOceanClient.cs
@@ -29,6 +29,7 @@ namespace DigitalOcean.API {
         IVolumesClient Volumes { get; }
         IVolumeActionsClient VolumeActions { get; }
         IBalanceClient BalanceClient { get; }
+        IVpcClient Vpc { get; }
 
         IRateLimit Rates { get; }
     }

--- a/DigitalOcean.API/Models/Requests/DatabaseBackup.cs
+++ b/DigitalOcean.API/Models/Requests/DatabaseBackup.cs
@@ -46,6 +46,13 @@ namespace DigitalOcean.API.Models.Requests {
         public List<string> Tags { get; set; }
 
         /// <summary>
+        /// A string specifying the UUID of the VPC to which the database cluster will be assigned.
+        /// If excluded, the cluster will be assigned to your account's default VPC for the region.
+        /// </summary>
+        [JsonProperty("private_network_uuid")]
+        public string PrivateNetworkUuid { get; set; }
+
+        /// <summary>
         /// An embedded object containing two attributes specifying the name of the original database cluster and the timestamp of the backup to restore (see below).
         /// </summary>
         [JsonProperty("backup_restore")]

--- a/DigitalOcean.API/Models/Requests/DatabaseCluster.cs
+++ b/DigitalOcean.API/Models/Requests/DatabaseCluster.cs
@@ -44,5 +44,12 @@ namespace DigitalOcean.API.Models.Requests {
         /// </summary>
         [JsonProperty("tags")]
         public List<string> Tags { get; set; }
+
+        /// <summary>
+        /// A string specifying the UUID of the VPC to which the database cluster will be assigned.
+        /// If excluded, the cluster will be assigned to your account's default VPC for the region.
+        /// </summary>
+        [JsonProperty("private_network_uuid")]
+        public string PrivateNetworkUuid { get; set; }
     }
 }

--- a/DigitalOcean.API/Models/Requests/Droplet.cs
+++ b/DigitalOcean.API/Models/Requests/Droplet.cs
@@ -51,8 +51,9 @@ namespace DigitalOcean.API.Models.Requests {
         public bool? Ipv6 { get; set; }
 
         /// <summary>
-        /// A boolean indicating whether private networking is enabled for the Droplet. Private networking is currently only
-        /// available in certain regions.
+        /// A boolean indicating whether private networking is enabled.
+        /// When VPC is enabled on an account, this will provision the Droplet inside of your account's default VPC for the region.
+        /// Use the "vpc_uuid" attribute to specify a different VPC.
         /// </summary>
         [JsonProperty("private_networking")]
         public bool? PrivateNetworking { get; set; }
@@ -83,5 +84,12 @@ namespace DigitalOcean.API.Models.Requests {
         /// </summary>
         [JsonProperty("volumes")]
         public List<string> Volumes { get; set; }
+
+        /// <summary>
+        /// A string specifying the UUID of the VPC to which the Droplet will be assigned.
+        /// If excluded, beginning on April 7th, 2020, the Droplet will be assigned to your account's default VPC for the region.
+        /// </summary>
+        [JsonProperty("vpc_uuid")]
+        public string VpcUuid { get; set; }
     }
 }

--- a/DigitalOcean.API/Models/Requests/Droplets.cs
+++ b/DigitalOcean.API/Models/Requests/Droplets.cs
@@ -51,8 +51,9 @@ namespace DigitalOcean.API.Models.Requests {
         public bool? Ipv6 { get; set; }
 
         /// <summary>
-        /// A boolean indicating whether private networking is enabled for the Droplet. Private networking is currently only
-        /// available in certain regions.
+        /// A boolean indicating whether private networking is enabled.
+        /// When VPC is enabled on an account, this will provision the Droplet inside of your account's default VPC for the region.
+        /// Use the "vpc_uuid" attribute to specify a different VPC.
         /// </summary>
         [JsonProperty("private_networking")]
         public bool? PrivateNetworking { get; set; }
@@ -76,5 +77,12 @@ namespace DigitalOcean.API.Models.Requests {
         /// </summary>
         [JsonProperty("tags")]
         public List<string> Tags { get; set; }
+
+        /// <summary>
+        /// A string specifying the UUID of the VPC to which the Droplet will be assigned.
+        /// If excluded, beginning on April 7th, 2020, the Droplet will be assigned to your account's default VPC for the region.
+        /// </summary>
+        [JsonProperty("vpc_uuid")]
+        public string VpcUuid { get; set; }
     }
 }

--- a/DigitalOcean.API/Models/Requests/KubernetesCluster.cs
+++ b/DigitalOcean.API/Models/Requests/KubernetesCluster.cs
@@ -44,5 +44,12 @@ namespace DigitalOcean.API.Models.Requests {
         /// </summary>
         [JsonProperty("node_pools")]
         public List<KubernetesNodePool> NodePools { get; set; }
+
+        /// <summary>
+        /// A string specifying the UUID of the VPC to which the Kubernetes cluster will be assigned.
+        /// If excluded, the cluster will be assigned to your account's default VPC for the region.
+        /// </summary>
+        [JsonProperty("vpc_uuid")]
+        public string VpcUuid { get; set; }
     }
 }

--- a/DigitalOcean.API/Models/Requests/LoadBalancer.cs
+++ b/DigitalOcean.API/Models/Requests/LoadBalancer.cs
@@ -69,5 +69,12 @@ namespace DigitalOcean.API.Models.Requests {
 		/// </summary>
 		[JsonProperty("tag")]
 		public string Tag { get; set; }
+
+        /// <summary>
+        /// A string specifying the UUID of the VPC to which the load balancer will be assigned.
+        /// If excluded, the load balancer will be assigned to your account's default VPC for the region.
+        /// </summary>
+        [JsonProperty("vpc_uuid")]
+        public string VpcUuid { get; set; }
 	}
 }

--- a/DigitalOcean.API/Models/Requests/UpdateVpc.cs
+++ b/DigitalOcean.API/Models/Requests/UpdateVpc.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Requests {
+    public class UpdateVpc {
+        /// <summary>
+        /// The name of the VPC.
+        /// Must be unique and contain alphanumeric characters, dashes, and periods only.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A free-form text field for describing the VPC's purpose.
+        /// It may be a maximum of 255 characters.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+    }
+}

--- a/DigitalOcean.API/Models/Requests/Vpc.cs
+++ b/DigitalOcean.API/Models/Requests/Vpc.cs
@@ -1,0 +1,33 @@
+using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Requests {
+    public class Vpc {
+        /// <summary>
+        /// The name of the VPC.
+        /// Must be unique and contain alphanumeric characters, dashes, and periods only.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A free-form text field for describing the VPC's purpose.
+        /// It may be a maximum of 255 characters.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The slug identifier for the region where the VPC will be created.
+        /// </summary>
+        [JsonProperty("region")]
+        public string Region { get; set; }
+
+        /// <summary>
+        /// The requested range of IP addresses for the VPC in CIDR notation.
+        /// Network ranges cannot overlap with other networks in the same account and must be in range of private
+        /// addresses as defined in RFC1918. It may not be smaller than /24 nor larger than /16.
+        /// </summary>
+        [JsonProperty("ip_range")]
+        public string IpRange { get; set; }
+    }
+}

--- a/DigitalOcean.API/Models/Responses/DatabaseCluster.cs
+++ b/DigitalOcean.API/Models/Responses/DatabaseCluster.cs
@@ -77,5 +77,10 @@ namespace DigitalOcean.API.Models.Responses {
         /// An array of tags that have been applied to the database cluster.
         /// </summary>
         public List<string> Tags { get; set; }
+
+        /// <summary>
+        /// A string specifying the UUID of the VPC to which the database cluster is assigned.
+        /// </summary>
+        public string PrivateNetworkUuid { get; set; }
     }
 }

--- a/DigitalOcean.API/Models/Responses/Droplet.cs
+++ b/DigitalOcean.API/Models/Responses/Droplet.cs
@@ -107,5 +107,10 @@ namespace DigitalOcean.API.Models.Responses {
         /// A flat array including the unique identifier for each Block Storage volume attached to the Droplet.
         /// </summary>
         public List<string> VolumeIds { get; set; }
+
+        /// <summary>
+        /// A string specifying the UUID of the VPC to which the Droplet is assigned.
+        /// </summary>
+        public string VpcUuid { get; set; }
     }
 }

--- a/DigitalOcean.API/Models/Responses/KubernetesCluster.cs
+++ b/DigitalOcean.API/Models/Responses/KubernetesCluster.cs
@@ -77,5 +77,10 @@ namespace DigitalOcean.API.Models.Responses {
         /// An object containing a "state" attribute whose value is set to a string indicating the current status of the node. Potential values include running, provisioning, and errored.
         /// </summary>
         public KubernetesNodeStatus Status { get; set; }
+
+        /// <summary>
+        /// A string specifying the UUID of the VPC to which the Kubernetes cluster is assigned.
+        /// </summary>
+        public string VpcUuid { get; set; }
     }
 }

--- a/DigitalOcean.API/Models/Responses/LoadBalancer.cs
+++ b/DigitalOcean.API/Models/Responses/LoadBalancer.cs
@@ -75,5 +75,10 @@ namespace DigitalOcean.API.Models.Responses {
 		///A boolean value indicating whether PROXY Protocol is in use.
 		/// </summary>
 		public bool EnableProxyProtocol { get; set; }
+
+        /// <summary>
+        /// A string specifying the UUID of the VPC to which the load balancer is assigned.
+        /// </summary>
+        public string VpcUuid { get; set; }
 	}
 }

--- a/DigitalOcean.API/Models/Responses/Vpc.cs
+++ b/DigitalOcean.API/Models/Responses/Vpc.cs
@@ -1,0 +1,51 @@
+using System;
+using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Responses {
+    public class Vpc {
+        /// <summary>
+        /// A unique ID that can be used to identify and reference the VPC.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The uniform resource name (URN) for the VPC.
+        /// </summary>
+        public string Urn { get; set; }
+
+        /// <summary>
+        /// The name of the VPC.
+        /// Must be unique and may only contain alphanumeric characters, dashes, and periods.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The name of the VPC.
+        /// Must be unique and may only contain alphanumeric characters, dashes, and periods.
+        /// </summary>
+        public string Region { get; set; }
+
+        /// <summary>
+        /// The range of IP addresses in the VPC in CIDR notation.
+        /// </summary>
+        [JsonProperty("ip_range")]
+        public string IpRange { get; set; }
+
+        /// <summary>
+        /// A free-form text field for describing the VPC's purpose.
+        /// It may be a maximum of 255 characters.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// A boolean value indicating whether or not the VPC is the default one for the region.
+        /// </summary>
+        public bool Default { get; set; }
+
+        /// <summary>
+        /// A time value given in ISO8601 combined date and time format.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/DigitalOcean.API/Models/Responses/VpcMember.cs
+++ b/DigitalOcean.API/Models/Responses/VpcMember.cs
@@ -1,0 +1,24 @@
+using System;
+using Newtonsoft.Json;
+
+namespace DigitalOcean.API.Models.Responses {
+    public class VpcMember {
+        /// <summary>
+        /// The name of the resource.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The uniform resource name (URN) for the resource in the format do:resource_type:resource_id.
+        /// </summary>
+        [JsonProperty("urn")]
+        public string Urn { get; set; }
+
+        /// <summary>
+        /// A time value given in ISO8601 combined date and time format that represents when the resource was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+    }
+}


### PR DESCRIPTION
Very recent API update: https://developers.digitalocean.com/documentation/changelog/api-v2/api-support-for-digitalocean-vpcs/

Implemented new VpcClient in usual layout, along with unit tests.

Also new proprties (vpc_uuid/private_network_uuid) in models for Droplets, DatabaseCluster KubernetesCluster, LoadBalancers.