### PR TITLE
Kubernetes now supports persistent node labels

### DIFF
--- a/DigitalOcean.API/Models/Requests/KubernetesCluster.cs
+++ b/DigitalOcean.API/Models/Requests/KubernetesCluster.cs
@@ -28,7 +28,8 @@ namespace DigitalOcean.API.Models.Requests {
         public bool? AutoUpgrade { get; set; }
 
         /// <summary>
-        /// A flat array of tag names as strings to be applied to the Kubernetes cluster. All clusters will be automatically tagged "k8s" and "k8s:$K8S_CLUSTER_ID" in addition to any tags provided by the user.
+        /// A flat array of tag names as strings to be applied to the Kubernetes cluster.
+        /// All clusters will be automatically tagged "k8s" and "k8s:$K8S_CLUSTER_ID" in addition to any tags provided by the user.
         /// </summary>
         [JsonProperty("tags")]
         public List<string> Tags { get; set; }

--- a/DigitalOcean.API/Models/Requests/KubernetesNodePool.cs
+++ b/DigitalOcean.API/Models/Requests/KubernetesNodePool.cs
@@ -22,9 +22,31 @@ namespace DigitalOcean.API.Models.Requests {
         public int Count { get; set; }
 
         /// <summary>
-        /// A flat array of tag names as strings to be applied to the node pool. All node pools will be automatically tagged "k8s," "k8s-worker," and "k8s:$K8S_CLUSTER_ID" in addition to any tags provided by the user.
+        /// An object containing a set of Kubernetes labels.
+        /// The keys are user-defined.
         /// </summary>
-        [JsonProperty("tags")]
-        public List<string> Tags { get; set; }
+        [JsonProperty("labels")]
+        public Dictionary<string, string> Labels { get; set; }
+
+        /// <summary>
+        /// A boolean value indicating whether auto-scaling is enabled for this node pool.
+        /// This requires DOKS versions at least 1.13.10-do.3, 1.14.6-do.3, or 1.15.3-do.3.
+        /// </summary>
+        [JsonProperty("auto_scale")]
+        public bool? AutoScale { get; set; }
+
+        /// <summary>
+        /// The minimum number of nodes that this node pool can be auto-scaled to.
+        /// This will fail validation if the additional nodes will exceed your account droplet limit.
+        /// </summary>
+        [JsonProperty("min_nodes")]
+        public string MinNodes { get; set; }
+
+        /// <summary>
+        /// The maximum number of nodes that this node pool can be auto-scaled to.
+        /// This can be 0, but your cluster must contain at least 1 node across all node pools.
+        /// </summary>
+        [JsonProperty("max_nodes")]
+        public string MaxNodes { get; set; }
     }
 }

--- a/DigitalOcean.API/Models/Requests/UpdateKubernetesNodePool.cs
+++ b/DigitalOcean.API/Models/Requests/UpdateKubernetesNodePool.cs
@@ -16,9 +16,31 @@ namespace DigitalOcean.API.Models.Requests {
         public int Count { get; set; }
 
         /// <summary>
-        /// A flat array of tag names as strings to be applied to the node pool. All node pools will be automatically tagged "k8s," "k8s-worker," and "k8s:$K8S_CLUSTER_ID" in addition to any tags provided by the user.
+        /// An object containing a set of Kubernetes labels.
+        /// The keys are user-defined.
         /// </summary>
-        [JsonProperty("tags")]
-        public List<string> Tags { get; set; }
+        [JsonProperty("labels")]
+        public Dictionary<string, string> Labels { get; set; }
+
+        /// <summary>
+        /// A boolean value indicating whether auto-scaling is enabled for this node pool.
+        /// This requires DOKS versions at least 1.13.10-do.3, 1.14.6-do.3, or 1.15.3-do.3.
+        /// </summary>
+        [JsonProperty("auto_scale")]
+        public bool? AutoScale { get; set; }
+
+        /// <summary>
+        /// The minimum number of nodes that this node pool can be auto-scaled to.
+        /// This will fail validation if the additional nodes will exceed your account droplet limit.
+        /// </summary>
+        [JsonProperty("min_nodes")]
+        public string MinNodes { get; set; }
+
+        /// <summary>
+        /// The maximum number of nodes that this node pool can be auto-scaled to.
+        /// This can be 0, but your cluster must contain at least 1 node across all node pools.
+        /// </summary>
+        [JsonProperty("max_nodes")]
+        public string MaxNodes { get; set; }
     }
 }

--- a/DigitalOcean.API/Models/Responses/KubernetesCluster.cs
+++ b/DigitalOcean.API/Models/Responses/KubernetesCluster.cs
@@ -49,7 +49,8 @@ namespace DigitalOcean.API.Models.Responses {
         public string ServiceSubset { get; set; }
 
         /// <summary>
-        /// An array of tags applied to the Kubernetes cluster. All clusters are automatically tagged "k8s" and "k8s:$K8S_CLUSTER_ID."
+        /// A flat array of tag names as strings to be applied to the Kubernetes cluster.
+        /// All clusters will be automatically tagged "k8s" and "k8s:$K8S_CLUSTER_ID" in addition to any tags provided by the user.
         /// </summary>
         public List<string> Tags { get; set; }
 

--- a/DigitalOcean.API/Models/Responses/KubernetesNodePool.cs
+++ b/DigitalOcean.API/Models/Responses/KubernetesNodePool.cs
@@ -23,13 +23,38 @@ namespace DigitalOcean.API.Models.Responses {
         public string Count { get; set; }
 
         /// <summary>
-        /// An array containing the tags applied to the node pool. All node pools are automatically tagged "k8s," "k8s-worker," and "k8s:$K8S_CLUSTER_ID."
+        /// An array containing the tags applied to the node pool.
+        /// All node pools are automatically tagged "k8s," "k8s-worker," and "k8s:$K8S_CLUSTER_ID."
         /// </summary>
         public List<string> Tags { get; set; }
+
+        /// <summary>
+        /// An object containing a set of Kubernetes labels.
+        /// The keys are user-defined.
+        /// </summary>
+        public Dictionary<string, string> Labels { get; set; }
 
         /// <summary>
         /// An object specifying the details of a specific worker node in a node pool
         /// </summary>
         public List<KubernetesNode> Nodes { get; set; }
+
+        /// <summary>
+        /// A boolean value indicating whether auto-scaling is enabled for this node pool.
+        /// This requires DOKS versions at least 1.13.10-do.3, 1.14.6-do.3, or 1.15.3-do.3.
+        /// </summary>
+        public bool? AutoScale { get; set; }
+
+        /// <summary>
+        /// The minimum number of nodes that this node pool can be auto-scaled to.
+        /// This will fail validation if the additional nodes will exceed your account droplet limit.
+        /// </summary>
+        public string MinNodes { get; set; }
+
+        /// <summary>
+        /// The maximum number of nodes that this node pool can be auto-scaled to.
+        /// This can be 0, but your cluster must contain at least 1 node across all node pools.
+        /// </summary>
+        public string MaxNodes { get; set; }
     }
 }


### PR DESCRIPTION
Another API update: https://developers.digitalocean.com/documentation/changelog/api-v2/kubernetes-node-labels/

New property `labels` in all NodePool classes. Also optional properties have been added: AutoScale, MinNodes, MaxNodes. 

Minor fix, according to documentation the NodePools in request body's do not contain a `tags` property, only the responses do. So removed them from request classes.