### PR TITLE
Changes to the Droplet Neighbors Report

### DIFF
--- a/DigitalOcean.API.Tests/Clients/DropletsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/DropletsClientTest.cs
@@ -148,5 +148,15 @@ namespace DigitalOcean.API.Tests.Clients {
 
             factory.Received().GetPaginated<Droplet>("reports/droplet_neighbors", null, "neighbors");
         }
+
+        [Fact]
+        public void CorrectRequestForListDropletNeighborIds() {
+            var factory = Substitute.For<IConnection>();
+            var client = new DropletsClient(factory);
+
+            client.ListDropletNeighborIds();
+
+            factory.Received().GetPaginated<List<long>>("reports/droplet_neighbors_ids", null, "neighbor_ids");
+        }
     }
 }

--- a/DigitalOcean.API/Clients/DropletsClient.cs
+++ b/DigitalOcean.API/Clients/DropletsClient.cs
@@ -134,8 +134,18 @@ namespace DigitalOcean.API.Clients {
         /// <summary>
         /// To retrieve a list of any Droplets that are running on the same physical hardware.
         /// </summary>
+        [System.Obsolete("Deprecated on December 17th, 2019")]
         public Task<IReadOnlyList<Droplet>> ListDropletNeighbors() {
             return _connection.GetPaginated<Droplet>("reports/droplet_neighbors", null, "neighbors");
+        }
+
+        /// <summary>
+        /// To retrieve a list of all Droplets that are co-located on the same physical hardware.
+        /// This will be set to an array of arrays. Each array will contain a set of Droplet IDs for Droplets that share a physical server.
+        /// An empty array indicates that all Droplets associated with your account are located on separate physical hardware.
+        /// </summary>
+        public Task<IReadOnlyList<List<long>>> ListDropletNeighborIds() {
+            return _connection.GetPaginated<List<long>>("reports/droplet_neighbors_ids", null, "neighbor_ids");
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/IDropletsClient.cs
+++ b/DigitalOcean.API/Clients/IDropletsClient.cs
@@ -69,6 +69,14 @@ namespace DigitalOcean.API.Clients {
         /// <summary>
         /// To retrieve a list of any Droplets that are running on the same physical hardware.
         /// </summary>
+        [System.Obsolete("Deprecated on December 17th, 2019")]
         Task<IReadOnlyList<Droplet>> ListDropletNeighbors();
+
+        /// <summary>
+        /// To retrieve a list of all Droplets that are co-located on the same physical hardware.
+        /// This will be set to an array of arrays. Each array will contain a set of Droplet IDs for Droplets that share a physical server.
+        /// An empty array indicates that all Droplets associated with your account are located on separate physical hardware.
+        /// </summary>
+        Task<IReadOnlyList<List<long>>> ListDropletNeighborIds();
     }
 }


### PR DESCRIPTION
API Update: https://developers.digitalocean.com/documentation/changelog/api-v2/changes-to-the-droplet-neighbors-report/

The droplet neighbors report endpoint has been deprecated since December 17th, 2019. Left method but marked with Obsolete attribute.

New neighbors endpoint added, just returns ids instead of full Droplet objects.