### PR TITLE
Upgrade RestSharp dependency

### DIFF
--- a/DigitalOcean.API.Tests/Clients/AppsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/AppsClientTest.cs
@@ -63,7 +63,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.DeleteApp("test");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string) list[0].Value == "test");
-            factory.Received().ExecuteRaw("apps/{appId}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("apps/{appId}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var specs = new Specs() {Spec = app};
             client.CreateNewApp(specs);
 
-            factory.Received().ExecuteRequest<App>("apps", null, specs, "app", Method.POST);
+            factory.Received().ExecuteRequest<App>("apps", null, specs, "app", Method.Post);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list =>
                 (string) list[0].Value == "test");
             factory.Received().ExecuteRequest<Deployment>("apps/{appId}/deployments", parameters, forceBuild,
-                "deployment", Method.POST);
+                "deployment", Method.Post);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list =>
                 (string) list[0].Value == "test" && (string) list[1].Value == "test2");
             factory.Received().ExecuteRequest<Deployment>("apps/{appId}/deployments/{deploymentId}", parameters, null,
-                "deployment", Method.POST);
+                "deployment", Method.Post);
         }
 
     }

--- a/DigitalOcean.API.Tests/Clients/CdnEndpointsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/CdnEndpointsClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -37,7 +37,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var body = new Models.Requests.CdnEndpoint();
             client.Create(body);
 
-            factory.Received().ExecuteRequest<CdnEndpoint>("cdn/endpoints", null, body, "endpoint", Method.POST);
+            factory.Received().ExecuteRequest<CdnEndpoint>("cdn/endpoints", null, body, "endpoint", Method.Post);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Update("endpoint:abc123", body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "endpoint:abc123");
-            factory.Received().ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, body, "endpoint", Method.PUT);
+            factory.Received().ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, body, "endpoint", Method.Put);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete("endpoint:abc123");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "endpoint:abc123");
-            factory.Received().ExecuteRaw("cdn/endpoints/{endpoint_id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("cdn/endpoints/{endpoint_id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.PurgeCache("endpoint:abc123", body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "endpoint:abc123");
-            factory.Received().ExecuteRaw("cdn/endpoints/{endpoint_id}/cache", parameters, body, Method.DELETE);
+            factory.Received().ExecuteRaw("cdn/endpoints/{endpoint_id}/cache", parameters, body, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/CertificatesClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/CertificatesClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -37,7 +37,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var body = new Models.Requests.Certificate();
             client.Create(body);
 
-            factory.Received().ExecuteRequest<Certificate>("certificates", null, body, "certificate", Method.POST);
+            factory.Received().ExecuteRequest<Certificate>("certificates", null, body, "certificate", Method.Post);
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete("certificate:abc123");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "certificate:abc123");
-            factory.Received().ExecuteRaw("certificates/{certificate_id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("certificates/{certificate_id}", parameters, null, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/ContainerRegistryClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/ContainerRegistryClientTest.cs
@@ -21,7 +21,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var data = new Models.Requests.ContainerRegistryConfigure();
             client.Configure(data);
-            factory.Received().ExecuteRequest<Models.Responses.ContainerRegistryConfigure>("registry", null, data, null, Method.POST);
+            factory.Received().ExecuteRequest<Models.Responses.ContainerRegistryConfigure>("registry", null, data, null, Method.Post);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var data = new UpdateSubscriptionTier();
             client.UpdateSubscriptionTier(data);
-            factory.Received().ExecuteRequest<SubscriptionTierUpdate>("registry/subscription", null, data, "subscription", Method.POST);
+            factory.Received().ExecuteRequest<SubscriptionTierUpdate>("registry/subscription", null, data, "subscription", Method.Post);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var client = new ContainerRegistryClient(factory);
 
             client.Delete();
-            factory.Received().ExecuteRaw("registry", null, null, Method.DELETE);
+            factory.Received().ExecuteRaw("registry", null, null, Method.Delete);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var data = new ContainerRegistryValidateName();
             client.ValidateName(data);
-            factory.Received().ExecuteRaw("registry/validate-name", null, data, Method.POST);
+            factory.Received().ExecuteRaw("registry/validate-name", null, data, Method.Post);
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             client.DeleteRepositoryTag("registryName", "repositoryName", "tag");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "registryName" && (string)list[1].Value == "repositoryName" && (string)list[2].Value == "tag");
-            factory.Received().ExecuteRaw("registry/{registryName}/repositories/{repositoryName}/tags/{tag}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("registry/{registryName}/repositories/{repositoryName}/tags/{tag}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             client.DeleteRepositoryManifest("registryName", "repositoryName", "manifestDigest");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "registryName" && (string)list[1].Value == "repositoryName");
-            factory.Received().ExecuteRaw("registry/{registryName}/repositories/{repositoryName}/digests/manifestDigest", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("registry/{registryName}/repositories/{repositoryName}/digests/manifestDigest", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             client.StartGarbageCollection("registryName");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "registryName");
-            factory.Received().ExecuteRequest<GarbageCollection>("registry/{registryName}/garbage-collection", parameters, null, "garbage_collections", Method.POST);
+            factory.Received().ExecuteRequest<GarbageCollection>("registry/{registryName}/garbage-collection", parameters, null, "garbage_collections", Method.Post);
         }
 
         [Fact]
@@ -158,7 +158,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var data = new UpdateGarbageCollection();
             client.UpdateGarbageCollection("registryName", "uuid", data);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "registryName" && (string)list[1].Value == "uuid");
-            factory.Received().ExecuteRequest<GarbageCollection>("registry/{registryName}/garbage-collection/{uuid}", parameters, data, "garbage_collections", Method.PUT);
+            factory.Received().ExecuteRequest<GarbageCollection>("registry/{registryName}/garbage-collection/{uuid}", parameters, data, "garbage_collections", Method.Put);
         }
 
         [Fact]

--- a/DigitalOcean.API.Tests/Clients/DatabasesClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/DatabasesClientTest.cs
@@ -15,7 +15,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var database = new Models.Requests.DatabaseCluster();
             client.Create(database);
-            factory.Received().ExecuteRequest<DatabaseCluster>("databases", null, database, "database", Method.POST);
+            factory.Received().ExecuteRequest<DatabaseCluster>("databases", null, database, "database", Method.Post);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Resize("1", resize);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("databases/{id}/resize", parameters, resize, Method.POST);
+            factory.Received().ExecuteRaw("databases/{id}/resize", parameters, resize, Method.Post);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Migrate("1", migrate);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("databases/{id}/migrate", parameters, migrate, Method.POST);
+            factory.Received().ExecuteRaw("databases/{id}/migrate", parameters, migrate, Method.Post);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Maintenance("1", maintenance);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("databases/{id}/maintenance", parameters, maintenance, Method.POST);
+            factory.Received().ExecuteRaw("databases/{id}/maintenance", parameters, maintenance, Method.Post);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var backup = new Models.Requests.DatabaseBackup();
             client.Restore(backup);
 
-            factory.Received().ExecuteRequest<DatabaseCluster>("databases", null, backup, "database", Method.POST);
+            factory.Received().ExecuteRequest<DatabaseCluster>("databases", null, backup, "database", Method.Post);
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             client.Delete("1");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("databases/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("databases/{id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.CreateReplica("1", replica);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRequest<DatabaseReplica>("databases/{id}/replicas", parameters, replica, "replica", Method.POST);
+            factory.Received().ExecuteRequest<DatabaseReplica>("databases/{id}/replicas", parameters, replica, "replica", Method.Post);
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.DeleteReplica("1", "example");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1" && (string)list[1].Value == "example");
-            factory.Received().ExecuteRaw("databases/{id}/replicas/{name}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("databases/{id}/replicas/{name}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -168,7 +168,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.AddUser("1", user);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRequest<DatabaseUser>("databases/{id}/users", parameters, user, "user", Method.POST);
+            factory.Received().ExecuteRequest<DatabaseUser>("databases/{id}/users", parameters, user, "user", Method.Post);
         }
 
         [Fact]
@@ -197,7 +197,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var client = new DatabasesClient(factory);
             client.RemoveUser("1", "name");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1" && (string)list[1].Value == "name");
-            factory.Received().ExecuteRaw("databases/{id}/users/{name}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("databases/{id}/users/{name}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -209,7 +209,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.ResetUserAuth("1", "name", body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1" && (string)list[1].Value == "name");
-            factory.Received().ExecuteRequest<DatabaseUser>("databases/{id}/users/{username}/reset_auth", parameters, body, "user", Method.POST);
+            factory.Received().ExecuteRequest<DatabaseUser>("databases/{id}/users/{username}/reset_auth", parameters, body, "user", Method.Post);
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var database = new Models.Requests.Database();
             client.AddDatabase("1", database);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRequest<Database>("databases/{id}/dbs", parameters, database, "db", Method.POST);
+            factory.Received().ExecuteRequest<Database>("databases/{id}/dbs", parameters, database, "db", Method.Post);
         }
 
         [Fact]
@@ -246,7 +246,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var client = new DatabasesClient(factory);
             client.DeleteDatabase("1", "name");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1" && (string)list[1].Value == "name");
-            factory.Received().ExecuteRaw("databases/{id}/dbs/{name}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("databases/{id}/dbs/{name}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -256,7 +256,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var pool = new Models.Requests.ConnectionPool();
             client.AddConnectionPool("1", pool);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRequest<ConnectionPool>("databases/{id}/pools", parameters, pool, "pool", Method.POST);
+            factory.Received().ExecuteRequest<ConnectionPool>("databases/{id}/pools", parameters, pool, "pool", Method.Post);
         }
 
         [Fact]
@@ -283,7 +283,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var client = new DatabasesClient(factory);
             client.DeleteConnectionPool("1", "name");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1" && (string)list[1].Value == "name");
-            factory.Received().ExecuteRaw("databases/{id}/pools/{name}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("databases/{id}/pools/{name}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -295,7 +295,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.UpdateFirewallRules("1", body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("databases/{id}/firewall", parameters, body, Method.PUT);
+            factory.Received().ExecuteRaw("databases/{id}/firewall", parameters, body, Method.Put);
         }
 
         [Fact]
@@ -329,7 +329,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.ConfigureEvictionPolicy("1", body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("databases/{id}/eviction_policy", parameters, body, Method.PUT);
+            factory.Received().ExecuteRaw("databases/{id}/eviction_policy", parameters, body, Method.Put);
         }
 
         [Fact]
@@ -352,7 +352,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.ConfigureSqlModes("1", body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("databases/{id}/sql_mode", parameters, body, Method.PUT);
+            factory.Received().ExecuteRaw("databases/{id}/sql_mode", parameters, body, Method.Put);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/DomainRecordsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/DomainRecordsClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -31,7 +31,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "vevix.net");
             factory.Received()
                 .ExecuteRequest<DomainRecord>("domains/{name}/records", parameters, data,
-                    "domain_record", Method.POST);
+                    "domain_record", Method.Post);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var parameters = Arg.Is<List<Parameter>>(list =>
                 (string)list[0].Value == "vevix.net" && (string)list[1].Value == 9001.ToString());
-            factory.Received().ExecuteRaw("domains/{name}/records/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("domains/{name}/records/{id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list =>
                 (string)list[0].Value == "vevix.net" && (string)list[1].Value == 9001.ToString());
             factory.Received().ExecuteRequest<DomainRecord>(
-                "domains/{name}/records/{id}", parameters, data, "domain_record", Method.PUT);
+                "domains/{name}/records/{id}", parameters, data, "domain_record", Method.Put);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/DomainsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/DomainsClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -25,7 +25,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var data = new Models.Requests.Domain { Name = "CNAME" };
             domainClient.Create(data);
 
-            factory.Received().ExecuteRequest<Domain>("domains", null, data, "domain", Method.POST);
+            factory.Received().ExecuteRequest<Domain>("domains", null, data, "domain", Method.Post);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace DigitalOcean.API.Tests.Clients {
             domainClient.Delete("vevix.net");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "vevix.net");
-            factory.Received().ExecuteRaw("domains/{name}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("domains/{name}", parameters, null, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/DropletActionsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/DropletActionsClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
@@ -19,7 +19,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "reboot");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "power_cycle");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "shutdown");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "power_off");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "power_on");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "password_reset");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "resize" && action.Size == "1024mb" && action.Disk == true);
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "restore" && (long)action.Image == 1009);
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "rebuild" && (long)action.Image == 1009);
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "rename" && action.Name == "testing");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "change_kernel" && action.KernelId == 1009);
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -162,7 +162,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "enable_ipv6");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -175,7 +175,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "enable_backups");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -188,7 +188,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "disable_backups");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -201,7 +201,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "enable_private_networking");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -214,7 +214,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<DropletAction>(action => action.Type == "snapshot" && action.Name == "testing");
             factory.Received().ExecuteRequest<Models.Responses.Action>("droplets/{dropletId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -240,7 +240,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Name == "tag_name" && (string)list[0].Value == "mytag");
             var body = Arg.Is<DropletAction>(action => action.Type == "reboot");
             factory.Received().ExecuteRequest<List<Models.Responses.Action>>("droplets/actions",
-                parameters, null, "actions", Method.POST);
+                parameters, null, "actions", Method.Post);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/DropletsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/DropletsClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -92,7 +92,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var body = new Models.Requests.Droplet();
             client.Create(body);
 
-            factory.Received().ExecuteRequest<Droplet>("droplets", null, body, "droplet", Method.POST);
+            factory.Received().ExecuteRequest<Droplet>("droplets", null, body, "droplet", Method.Post);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var body = new Models.Requests.Droplets();
             client.Create(body);
 
-            factory.Received().ExecuteRequest<List<Droplet>>("droplets", null, body, "droplets", Method.POST);
+            factory.Received().ExecuteRequest<List<Droplet>>("droplets", null, body, "droplets", Method.Post);
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete(9001);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
-            factory.Received().ExecuteRaw("droplets/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("droplets/{id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.DeleteByTag("notarealtag");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Name == "tag_name" && (string)list[0].Value == "notarealtag");
-            factory.Received().ExecuteRaw("droplets", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("droplets", parameters, null, Method.Delete);
         }
 
         [Fact]

--- a/DigitalOcean.API.Tests/Clients/FirewallsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/FirewallsClientTest.cs
@@ -15,7 +15,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var firewall = new Models.Requests.Firewall();
             client.Create(firewall);
-            factory.Received().ExecuteRequest<Firewall>("firewalls", null, firewall, "firewall", Method.POST);
+            factory.Received().ExecuteRequest<Firewall>("firewalls", null, firewall, "firewall", Method.Post);
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var firewall = new Models.Requests.Firewall();
             client.Update("1", firewall);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRequest<Firewall>("firewalls/{id}", parameters, firewall, "firewall", Method.PUT);
+            factory.Received().ExecuteRequest<Firewall>("firewalls/{id}", parameters, firewall, "firewall", Method.Put);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var client = new FirewallsClient(factory);
             client.Delete("1");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("firewalls/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("firewalls/{id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace DigitalOcean.API.Tests.Clients {
             };
             client.AddDroplets("1", droplets);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.POST);
+            factory.Received().ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.Post);
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace DigitalOcean.API.Tests.Clients {
             };
             client.RemoveDroplets("1", droplets);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.DELETE);
+            factory.Received().ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.Delete);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace DigitalOcean.API.Tests.Clients {
             };
             client.AddTags("1", tags);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.POST);
+            factory.Received().ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.Post);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace DigitalOcean.API.Tests.Clients {
             };
             client.RemoveTags("1", tags);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.DELETE);
+            factory.Received().ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.Delete);
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace DigitalOcean.API.Tests.Clients {
             };
             client.AddRules("1", rules);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.POST);
+            factory.Received().ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.Post);
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace DigitalOcean.API.Tests.Clients {
             };
             client.RemoveRules("1", rules);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.DELETE);
+            factory.Received().ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/FloatingIpActionsTest.cs
+++ b/DigitalOcean.API.Tests/Clients/FloatingIpActionsTest.cs
@@ -17,7 +17,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1.2.3.4");
             var body = Arg.Is<Models.Requests.FloatingIpAction>(action =>
                 action.Type == "assign" && action.DropletId == 0);
-            factory.Received().ExecuteRequest<Action>("floating_ips/{ip}/actions", parameters, body, "action", Method.POST);
+            factory.Received().ExecuteRequest<Action>("floating_ips/{ip}/actions", parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Unassign("1.2.3.4");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1.2.3.4");
             var body = Arg.Is<Models.Requests.FloatingIpAction>(action => action.Type == "unassign");
-            factory.Received().ExecuteRequest<Action>("floating_ips/{ip}/actions", parameters, body, "action", Method.POST);
+            factory.Received().ExecuteRequest<Action>("floating_ips/{ip}/actions", parameters, body, "action", Method.Post);
         }
 
         [Fact]

--- a/DigitalOcean.API.Tests/Clients/FloatingIpsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/FloatingIpsClientTest.cs
@@ -23,7 +23,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var body = new Models.Requests.FloatingIp();
             client.Create(body);
-            factory.Received().ExecuteRequest<FloatingIp>("floating_ips", null, body, "floating_ip", Method.POST);
+            factory.Received().ExecuteRequest<FloatingIp>("floating_ips", null, body, "floating_ip", Method.Post);
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             client.Delete("1.2.3.4");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1.2.3.4");
-            factory.Received().ExecuteRaw("floating_ips/{ip}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("floating_ips/{ip}", parameters, null, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/ImageActionsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/ImageActionsClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Requests;
@@ -18,7 +18,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<ImageAction>(action => action.Type == "transfer" && action.Region == "sfo1");
             factory.Received().ExecuteRequest<Models.Responses.Action>("images/{imageId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
             var body = Arg.Is<ImageAction>(action => action.Type == "convert");
             factory.Received().ExecuteRequest<Models.Responses.Action>("images/{imageId}/actions",
-                parameters, body, "action", Method.POST);
+                parameters, body, "action", Method.Post);
         }
 
         [Fact]

--- a/DigitalOcean.API.Tests/Clients/ImagesClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/ImagesClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Requests;
@@ -58,7 +58,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var body = new Models.Requests.Image();
             client.Create(body);
 
-            factory.Received().ExecuteRequest<Image>("images", null, body, "image", Method.POST);
+            factory.Received().ExecuteRequest<Image>("images", null, body, "image", Method.Post);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete(9001);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
-            factory.Received().ExecuteRaw("images/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("images/{id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Update(9001, body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
-            factory.Received().ExecuteRequest<Image>("images/{id}", parameters, body, "image", Method.PUT);
+            factory.Received().ExecuteRequest<Image>("images/{id}", parameters, body, "image", Method.Put);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/KeysClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/KeysClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -30,7 +30,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var body = new Models.Requests.Key { Name = "example" };
             client.Create(body);
 
-            factory.Received().ExecuteRequest<Key>("account/keys", null, body, "ssh_key", Method.POST);
+            factory.Received().ExecuteRequest<Key>("account/keys", null, body, "ssh_key", Method.Post);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Update(9001L, body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
-            factory.Received().ExecuteRequest<Key>("account/keys/{id}", parameters, body, "ssh_key", Method.PUT);
+            factory.Received().ExecuteRequest<Key>("account/keys/{id}", parameters, body, "ssh_key", Method.Put);
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete(9001L);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == 9001.ToString());
-            factory.Received().ExecuteRaw("account/keys/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("account/keys/{id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete("fingerprint");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "fingerprint");
-            factory.Received().ExecuteRaw("account/keys/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("account/keys/{id}", parameters, null, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/KubernetesClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/KubernetesClientTest.cs
@@ -14,7 +14,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var client = new KubernetesClient(factory);
             var cluster = new Models.Requests.KubernetesCluster();
             client.Create(cluster);
-            factory.Received().ExecuteRequest<KubernetesCluster>("kubernetes/clusters", null, cluster, "kubernetes_cluster", Method.POST);
+            factory.Received().ExecuteRequest<KubernetesCluster>("kubernetes/clusters", null, cluster, "kubernetes_cluster", Method.Post);
         }
 
         [Fact]
@@ -41,7 +41,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var update = new Models.Requests.UpdateKubernetesCluster();
             client.Update("1", update);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRequest<KubernetesCluster>("kubernetes/clusters/{id}", parameters, update, "kubernetes_cluster", Method.PUT);
+            factory.Received().ExecuteRequest<KubernetesCluster>("kubernetes/clusters/{id}", parameters, update, "kubernetes_cluster", Method.Put);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var upgrade = new Models.Requests.KubernetesUpgrade();
             client.Upgrade("1", upgrade);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("kubernetes/clusters/{id}/upgrade", parameters, upgrade, Method.POST);
+            factory.Received().ExecuteRaw("kubernetes/clusters/{id}/upgrade", parameters, upgrade, Method.Post);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var client = new KubernetesClient(factory);
             client.Delete("1");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("kubernetes/clusters/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("kubernetes/clusters/{id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var client = new KubernetesClient(factory);
             client.GetKubeConfig("1");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRaw("kubernetes/clusters/{id}/kubeconfig", parameters, null, Method.GET);
+            factory.Received().ExecuteRaw("kubernetes/clusters/{id}/kubeconfig", parameters, null, Method.Get);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var pool = new Models.Requests.KubernetesNodePool();
             client.AddNodePool("1", pool);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1");
-            factory.Received().ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools", parameters, pool, "node_pool", Method.POST);
+            factory.Received().ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools", parameters, pool, "node_pool", Method.Post);
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var pool = new Models.Requests.UpdateKubernetesNodePool();
             client.UpdateNodePool("1", "2", pool);
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1" && (string)list[1].Value == "2");
-            factory.Received().ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, pool, "node_pool", Method.PUT);
+            factory.Received().ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, pool, "node_pool", Method.Put);
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var client = new KubernetesClient(factory);
             client.DeleteNodePool("1", "2");
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "1" && (string)list[1].Value == "2");
-            factory.Received().ExecuteRaw("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, null, Method.Delete);
         }
 
         [Fact]

--- a/DigitalOcean.API.Tests/Clients/LoadBalancerClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/LoadBalancerClientTest.cs
@@ -1,4 +1,4 @@
-﻿using DigitalOcean.API.Clients;
+using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Requests;
 using NSubstitute;
@@ -27,7 +27,7 @@ namespace DigitalOcean.API.Tests.Clients {
 			var body = new LoadBalancer();
 			client.Create(body);
 
-			factory.Received().ExecuteRequest<Models.Responses.LoadBalancer>("load_balancers", null, body, "load_balancers", Method.POST);
+			factory.Received().ExecuteRequest<Models.Responses.LoadBalancer>("load_balancers", null, body, "load_balancers", Method.Post);
 		}
 
 		[Fact]
@@ -38,7 +38,7 @@ namespace DigitalOcean.API.Tests.Clients {
 			client.Delete("10");
 
 			var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "10");
-			factory.Received().ExecuteRaw("load_balancers/{id}", null, parameters, Method.DELETE);
+			factory.Received().ExecuteRaw("load_balancers/{id}", null, parameters, Method.Delete);
 		}
 
 		[Fact]
@@ -49,7 +49,7 @@ namespace DigitalOcean.API.Tests.Clients {
 			client.Get("15");
 
 			var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "15");
-			factory.Received().ExecuteRequest<Models.Responses.LoadBalancer>("load_balancers/{id}", null, parameters, "load_balancers", Method.GET);
+			factory.Received().ExecuteRequest<Models.Responses.LoadBalancer>("load_balancers/{id}", null, parameters, "load_balancers", Method.Get);
 		}
 
 		[Fact]
@@ -61,7 +61,7 @@ namespace DigitalOcean.API.Tests.Clients {
 			client.Update("15",body);
 
 			var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "15");
-			factory.Received().ExecuteRequest<Models.Responses.LoadBalancer>("load_balancers/{id}", parameters, body, "load_balancers", Method.PUT);
+			factory.Received().ExecuteRequest<Models.Responses.LoadBalancer>("load_balancers/{id}", parameters, body, "load_balancers", Method.Put);
 		}
 
 		[Fact]
@@ -73,7 +73,7 @@ namespace DigitalOcean.API.Tests.Clients {
 			client.AddDroplets("15", body);
 
 			var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "15");
-			factory.Received().ExecuteRaw("load_balancers/{id}/droplets", parameters, body, Method.POST);
+			factory.Received().ExecuteRaw("load_balancers/{id}/droplets", parameters, body, Method.Post);
 		}
 
 		[Fact]
@@ -85,7 +85,7 @@ namespace DigitalOcean.API.Tests.Clients {
 			client.RemoveDroplets("15", body);
 
 			var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "15");
-			factory.Received().ExecuteRaw("load_balancers/{id}/droplets", parameters, body,  Method.DELETE);
+			factory.Received().ExecuteRaw("load_balancers/{id}/droplets", parameters, body,  Method.Delete);
 		}
 
 		[Fact]
@@ -103,7 +103,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
 			var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "15");
 			var body = Arg.Is<ForwardingRulesList>(ls => ls.ForwardingRules.SequenceEqual(requestBody.ForwardingRules));
-			factory.Received().ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, body, Method.POST);
+			factory.Received().ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, body, Method.Post);
 		}
 
 		[Fact]
@@ -121,7 +121,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
 			var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "15");
 			var body = Arg.Is<ForwardingRulesList>(ls => ls.ForwardingRules.SequenceEqual(requestBody.ForwardingRules));
-			factory.Received().ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, body, Method.DELETE);
+			factory.Received().ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, body, Method.Delete);
 		}
 	}
 }

--- a/DigitalOcean.API.Tests/Clients/ProjectResourcesClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/ProjectResourcesClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Requests;
@@ -39,7 +39,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.AssignResources("project:abc123", body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "project:abc123");
-            factory.Received().ExecuteRequest<List<ProjectResource>>("projects/{project_id}/resources", parameters, body, "resources", Method.POST);
+            factory.Received().ExecuteRequest<List<ProjectResource>>("projects/{project_id}/resources", parameters, body, "resources", Method.Post);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var body = new AssignResourceNames();
             client.AssignDefaultResources(body);
 
-            factory.Received().ExecuteRequest<List<ProjectResource>>("projects/default/resources", null, body, "resources", Method.POST);
+            factory.Received().ExecuteRequest<List<ProjectResource>>("projects/default/resources", null, body, "resources", Method.Post);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/ProjectsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/ProjectsClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -25,7 +25,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var data = new Models.Requests.Project();
             client.Create(data);
 
-            factory.Received().ExecuteRequest<Project>("projects", null, data, "project", Method.POST);
+            factory.Received().ExecuteRequest<Project>("projects", null, data, "project", Method.Post);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Update("project:abc123", data);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "project:abc123");
-            factory.Received().ExecuteRequest<Project>("projects/{project_id}", parameters, data, "project", Method.PUT);
+            factory.Received().ExecuteRequest<Project>("projects/{project_id}", parameters, data, "project", Method.Put);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var data = new Models.Requests.UpdateProject();
             client.UpdateDefault(data);
 
-            factory.Received().ExecuteRequest<Project>("projects/default", null, data, "project", Method.PUT);
+            factory.Received().ExecuteRequest<Project>("projects/default", null, data, "project", Method.Put);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Patch("project:abc123", data);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "project:abc123");
-            factory.Received().ExecuteRequest<Project>("projects/{project_id}", parameters, data, "project", Method.PATCH);
+            factory.Received().ExecuteRequest<Project>("projects/{project_id}", parameters, data, "project", Method.Patch);
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var data = new Models.Requests.PatchProject();
             client.PatchDefault(data);
 
-            factory.Received().ExecuteRequest<Project>("projects/default", null, data, "project", Method.PATCH);
+            factory.Received().ExecuteRequest<Project>("projects/default", null, data, "project", Method.Patch);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete("notarealid");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "notarealid");
-            factory.Received().ExecuteRaw("projects/{project_id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("projects/{project_id}", parameters, null, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/SnapshotsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/SnapshotsClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Requests;
@@ -43,7 +43,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete("snapshot:abc123");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "snapshot:abc123");
-            factory.Received().ExecuteRaw("snapshots/{snapshot_id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("snapshots/{snapshot_id}", parameters, null, Method.Delete);
         }
 
     }

--- a/DigitalOcean.API.Tests/Clients/TagsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/TagsClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
@@ -37,7 +37,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             client.Create("notarealtag");
 
-            factory.Received().ExecuteRequest<Tag>("tags", null, Arg.Is<Models.Requests.Tag>(data => data.Name == "notarealtag"), "tag", Method.POST);
+            factory.Received().ExecuteRequest<Tag>("tags", null, Arg.Is<Models.Requests.Tag>(data => data.Name == "notarealtag"), "tag", Method.Post);
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete("notarealtag");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "notarealtag");
-            factory.Received().ExecuteRaw("tags/{name}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("tags/{name}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "notarealtag");
             var body = Arg.Is<Models.Requests.TagResources>(tr => tr.Resources.SequenceEqual(resources.Resources));
-            factory.Received().ExecuteRaw("tags/{name}/resources", parameters, body, Method.POST);
+            factory.Received().ExecuteRaw("tags/{name}/resources", parameters, body, Method.Post);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "notarealtag");
             var body = Arg.Is<Models.Requests.TagResources>(tr => tr.Resources.SequenceEqual(resources.Resources));
-            factory.Received().ExecuteRaw("tags/{name}/resources", parameters, body, Method.DELETE);
+            factory.Received().ExecuteRaw("tags/{name}/resources", parameters, body, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/VolumeActionsClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/VolumeActionsClientTest.cs
@@ -20,7 +20,7 @@ namespace DigitalOcean.API.Tests.Clients {
                 action.Type == "attach" &&
                 action.DropletId == 0 &&
                 action.Region == "nyc3");
-            factory.Received().ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.POST);
+            factory.Received().ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace DigitalOcean.API.Tests.Clients {
                 action.DropletId == 0 &&
                 action.VolumeName == "name" &&
                 action.Region == "nyc3");
-            factory.Received().ExecuteRequest<Action>("volumes/actions", null, body, "action", Method.POST);
+            factory.Received().ExecuteRequest<Action>("volumes/actions", null, body, "action", Method.Post);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace DigitalOcean.API.Tests.Clients {
                 action.Type == "detach" &&
                 action.DropletId == 0 &&
                 action.Region == "nyc3");
-            factory.Received().ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.POST);
+            factory.Received().ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.Post);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace DigitalOcean.API.Tests.Clients {
                 action.DropletId == 0 &&
                 action.VolumeName == "name" &&
                 action.Region == "nyc3");
-            factory.Received().ExecuteRequest<Action>("volumes/actions", null, body, "action", Method.POST);
+            factory.Received().ExecuteRequest<Action>("volumes/actions", null, body, "action", Method.Post);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace DigitalOcean.API.Tests.Clients {
                 action.Type == "resize" &&
                 action.SizeGigabytes == 0 &&
                 action.Region == "nyc3");
-            factory.Received().ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.POST);
+            factory.Received().ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.Post);
         }
 
         [Fact]

--- a/DigitalOcean.API.Tests/Clients/VolumesClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/VolumesClientTest.cs
@@ -24,7 +24,7 @@ namespace DigitalOcean.API.Tests.Clients {
 
             var data = new Models.Requests.Volume();
             volumesClient.Create(data);
-            factory.Received().ExecuteRequest<Volume>("volumes", null, data, "volume", Method.POST);
+            factory.Received().ExecuteRequest<Volume>("volumes", null, data, "volume", Method.Post);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace DigitalOcean.API.Tests.Clients {
             volumesClient.CreateSnapshot("id", snapshot);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "id");
-            factory.Received().ExecuteRequest<Snapshot>("volumes/{id}/snapshots", parameters, snapshot, "snapshot", Method.POST);
+            factory.Received().ExecuteRequest<Snapshot>("volumes/{id}/snapshots", parameters, snapshot, "snapshot", Method.Post);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace DigitalOcean.API.Tests.Clients {
             volumesClient.Delete("id");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "id");
-            factory.Received().ExecuteRaw("volumes/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("volumes/{id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace DigitalOcean.API.Tests.Clients {
             volumesClient.DeleteByName("name", "region");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "name" && (string)list[1].Value == "region");
-            factory.Received().ExecuteRaw("volumes", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("volumes", parameters, null, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API.Tests/Clients/VpcClientTest.cs
+++ b/DigitalOcean.API.Tests/Clients/VpcClientTest.cs
@@ -26,7 +26,7 @@ namespace DigitalOcean.API.Tests.Clients {
             var body = new Models.Requests.Vpc();
             client.Create(body);
 
-            factory.Received().ExecuteRequest<Vpc>("vpcs", null, body, "vpc", Method.POST);
+            factory.Received().ExecuteRequest<Vpc>("vpcs", null, body, "vpc", Method.Post);
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Delete("abcdefg");
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "abcdefg");
-            factory.Received().ExecuteRaw("vpcs/{id}", parameters, null, Method.DELETE);
+            factory.Received().ExecuteRaw("vpcs/{id}", parameters, null, Method.Delete);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.Update("abcdefg", body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "abcdefg");
-            factory.Received().ExecuteRequest<Vpc>("vpcs/{id}", parameters, body, "vpc", Method.PUT);
+            factory.Received().ExecuteRequest<Vpc>("vpcs/{id}", parameters, body, "vpc", Method.Put);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace DigitalOcean.API.Tests.Clients {
             client.PartialUpdate("abcdefg", body);
 
             var parameters = Arg.Is<List<Parameter>>(list => (string)list[0].Value == "abcdefg");
-            factory.Received().ExecuteRequest<Vpc>("vpcs/{id}", parameters, body, "vpc", Method.PATCH);
+            factory.Received().ExecuteRequest<Vpc>("vpcs/{id}", parameters, body, "vpc", Method.Patch);
         }
 
         [Fact]

--- a/DigitalOcean.API.Tests/DigitalOcean.API.Tests.csproj
+++ b/DigitalOcean.API.Tests/DigitalOcean.API.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.2.2" />

--- a/DigitalOcean.API.Tests/DigitalOcean.API.Tests.csproj
+++ b/DigitalOcean.API.Tests/DigitalOcean.API.Tests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.2.2" />

--- a/DigitalOcean.API/Clients/ActionsClient.cs
+++ b/DigitalOcean.API/Clients/ActionsClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -26,7 +26,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Get(long actionId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", actionId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", actionId.ToString())
             };
             return _connection.ExecuteRequest<Action>("actions/{id}", parameters, null, "action");
         }

--- a/DigitalOcean.API/Clients/AppsClient.cs
+++ b/DigitalOcean.API/Clients/AppsClient.cs
@@ -22,22 +22,22 @@ namespace DigitalOcean.API.Clients {
 
         public Task<App> RetrieveExistingApp(string appId) {
             var parameters = new List<Parameter> {
-                new Parameter("appId", appId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("appId", appId)
             };
             return _connection.ExecuteRequest<App>("apps/{appId}", parameters, null, "app");
         }
 
         public Task<IReadOnlyList<Deployment>> ListAppDeployments(string appId) {
             var parameters = new List<Parameter> {
-                new Parameter("appId", appId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("appId", appId)
             };
             return _connection.GetPaginated<Deployment>("apps/{appId}/deployments", parameters, "deployments");
         }
 
         public Task<Deployment> RetrieveAppDeployment(string appId, string deploymentId) {
             var parameters = new List<Parameter> {
-                new Parameter("appId", appId, ParameterType.UrlSegment),
-                new Parameter("deploymentId", deploymentId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("appId", appId),
+                new UrlSegmentParameter("deploymentId", deploymentId)
             };
             return _connection.ExecuteRequest<Deployment>("apps/{appId}/deployments/{deploymentId}", parameters, null,
                 "deployment");
@@ -45,31 +45,31 @@ namespace DigitalOcean.API.Clients {
 
         public Task DeleteApp(string appId) {
             var parameters = new List<Parameter> {
-                new Parameter("appId", appId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("appId", appId)
             };
-            return _connection.ExecuteRaw("apps/{appId}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("apps/{appId}", parameters, null, Method.Delete);
         }
 
         public Task<App> CreateNewApp(Specs specs) {
-            return _connection.ExecuteRequest<App>("apps", null, specs, "app", Method.POST);
+            return _connection.ExecuteRequest<App>("apps", null, specs, "app", Method.Post);
         }
 
         public Task<Deployment> CreateNewDeployment(string appId, ForceBuildApp forceBuild) {
             var parameters = new List<Parameter> {
-                new Parameter("appId", appId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("appId", appId)
             };
 
             return _connection.ExecuteRequest<Deployment>("apps/{appId}/deployments", parameters,
-                forceBuild, "deployment", Method.POST);
+                forceBuild, "deployment", Method.Post);
         }
 
         public Task<Deployment> CancelDeployment(string appId, string deploymentId) {
             var parameters = new List<Parameter> {
-                new Parameter("appId", appId, ParameterType.UrlSegment),
-                new Parameter("deploymentId", deploymentId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("appId", appId),
+                new UrlSegmentParameter("deploymentId", deploymentId)
             };
             return _connection.ExecuteRequest<Deployment>("apps/{appId}/deployments/{deploymentId}", parameters, null,
-                "deployment", Method.POST);
+                "deployment", Method.Post);
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/CdnEndpointsClient.cs
+++ b/DigitalOcean.API/Clients/CdnEndpointsClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -24,7 +24,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<CdnEndpoint> Get(string endpointId) {
             var parameters = new List<Parameter> {
-                new Parameter("endpoint_id", endpointId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("endpoint_id", endpointId)
             };
             return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, null, "endpoint");
         }
@@ -34,7 +34,7 @@ namespace DigitalOcean.API.Clients {
         /// The Origin attribute must be set to the fully qualified domain name (FQDN) of a DigitalOcean Space.
         /// </summary>
         public Task<CdnEndpoint> Create(Models.Requests.CdnEndpoint endpoint) {
-            return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints", null, endpoint, "endpoint", Method.POST);
+            return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints", null, endpoint, "endpoint", Method.Post);
         }
 
         /// <summary>
@@ -42,9 +42,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<CdnEndpoint> Update(string endpointId, Models.Requests.UpdateCdnEndpoint updateEndpoint) {
             var parameters = new List<Parameter> {
-                new Parameter("endpoint_id", endpointId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("endpoint_id", endpointId)
             };
-            return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, updateEndpoint, "endpoint", Method.PUT);
+            return _connection.ExecuteRequest<CdnEndpoint>("cdn/endpoints/{endpoint_id}", parameters, updateEndpoint, "endpoint", Method.Put);
         }
 
         /// <summary>
@@ -52,9 +52,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string endpointId) {
             var parameters = new List<Parameter> {
-                new Parameter("endpoint_id", endpointId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("endpoint_id", endpointId)
             };
-            return _connection.ExecuteRaw("cdn/endpoints/{endpoint_id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("cdn/endpoints/{endpoint_id}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -64,9 +64,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task PurgeCache(string endpointId, Models.Requests.PurgeCdnFiles purgeFiles) {
             var parameters = new List<Parameter> {
-                new Parameter("endpoint_id", endpointId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("endpoint_id", endpointId)
             };
-            return _connection.ExecuteRaw("cdn/endpoints/{endpoint_id}/cache", parameters, purgeFiles, Method.DELETE);
+            return _connection.ExecuteRaw("cdn/endpoints/{endpoint_id}/cache", parameters, purgeFiles, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API/Clients/CertificatesClient.cs
+++ b/DigitalOcean.API/Clients/CertificatesClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -24,7 +24,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Certificate> Get(string certificateId) {
             var parameters = new List<Parameter> {
-                new Parameter("certificate_id", certificateId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("certificate_id", certificateId)
             };
             return _connection.ExecuteRequest<Certificate>("certificates/{certificate_id}", parameters, null, "certificate");
         }
@@ -39,7 +39,7 @@ namespace DigitalOcean.API.Clients {
         /// attributes should be provided. The type must be set to "custom".
         /// </summary>
         public Task<Certificate> Create(Models.Requests.Certificate certificate) {
-            return _connection.ExecuteRequest<Certificate>("certificates", null, certificate, "certificate", Method.POST);
+            return _connection.ExecuteRequest<Certificate>("certificates", null, certificate, "certificate", Method.Post);
         }
 
         /// <summary>
@@ -47,9 +47,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string certificateId) {
             var parameters = new List<Parameter> {
-                new Parameter("certificate_id", certificateId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("certificate_id", certificateId)
             };
-            return _connection.ExecuteRaw("certificates/{certificate_id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("certificates/{certificate_id}", parameters, null, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API/Clients/ContainerRegistryClient.cs
+++ b/DigitalOcean.API/Clients/ContainerRegistryClient.cs
@@ -21,7 +21,7 @@ namespace DigitalOcean.API.Clients {
         /// Configure your container registry.
         /// </summary>
         public Task<Models.Responses.ContainerRegistryConfigure> Configure(Models.Requests.ContainerRegistryConfigure containerRegistryConfigure) {
-            return _connection.ExecuteRequest<Models.Responses.ContainerRegistryConfigure>("registry", null, containerRegistryConfigure, null, Method.POST);
+            return _connection.ExecuteRequest<Models.Responses.ContainerRegistryConfigure>("registry", null, containerRegistryConfigure, null, Method.Post);
         }
 
         /// <summary>
@@ -49,21 +49,21 @@ namespace DigitalOcean.API.Clients {
         /// Updates your subscription tier.
         /// </summary>
         public Task<SubscriptionTierUpdate> UpdateSubscriptionTier(UpdateSubscriptionTier updateSubscriptionTier) {
-            return _connection.ExecuteRequest<SubscriptionTierUpdate>("registry/subscription", null, updateSubscriptionTier, "subscription", Method.POST);
+            return _connection.ExecuteRequest<SubscriptionTierUpdate>("registry/subscription", null, updateSubscriptionTier, "subscription", Method.Post);
         }
 
         /// <summary>
         /// Deletes your container registry.
         /// </summary>
         public Task Delete() {
-            return _connection.ExecuteRaw("registry", null, null, Method.DELETE);
+            return _connection.ExecuteRaw("registry", null, null, Method.Delete);
         }
 
         /// <summary>
         /// Validates a container registry name.
         /// </summary>
         public Task ValidateName(ContainerRegistryValidateName containerRegistryValidateName) {
-            return _connection.ExecuteRaw("registry/validate-name", null, containerRegistryValidateName, Method.POST);
+            return _connection.ExecuteRaw("registry/validate-name", null, containerRegistryValidateName, Method.Post);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ContainerRegistryRepository>> GetAllRepositories(string registryName) {
             var parameters = new List<Parameter> {
-                new Parameter(nameof(registryName), registryName, ParameterType.UrlSegment)
+                new UrlSegmentParameter (nameof(registryName), registryName)
             };
 
             return _connection.GetPaginated<ContainerRegistryRepository>($"registry/{{{nameof(registryName)}}}/repositories", parameters, "repositories");
@@ -82,8 +82,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ContainerRegistryTag>> GetAllRepositoryTags(string registryName, string repositoryName) {
             var parameters = new List<Parameter> {
-                new Parameter(nameof(registryName), registryName, ParameterType.UrlSegment),
-                new Parameter(nameof(repositoryName), repositoryName, ParameterType.UrlSegment),
+                new UrlSegmentParameter (nameof(registryName), registryName),
+                new UrlSegmentParameter (nameof(repositoryName), repositoryName),
             };
 
             return _connection.GetPaginated<ContainerRegistryTag>($"registry/{{{nameof(registryName)}}}/repositories/{{{nameof(repositoryName)}}}/tags", parameters, "tags");
@@ -94,12 +94,12 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteRepositoryTag(string registryName, string repositoryName, string tag) {
             var parameters = new List<Parameter> {
-                new Parameter(nameof(registryName), registryName, ParameterType.UrlSegment),
-                new Parameter(nameof(repositoryName), repositoryName, ParameterType.UrlSegment),
-                new Parameter(nameof(tag), tag, ParameterType.UrlSegment),
+                new UrlSegmentParameter (nameof(registryName), registryName),
+                new UrlSegmentParameter (nameof(repositoryName), repositoryName),
+                new UrlSegmentParameter (nameof(tag), tag),
             };
 
-            return _connection.ExecuteRaw($"registry/{{{nameof(registryName)}}}/repositories/{{{nameof(repositoryName)}}}/tags/{{{nameof(tag)}}}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw($"registry/{{{nameof(registryName)}}}/repositories/{{{nameof(repositoryName)}}}/tags/{{{nameof(tag)}}}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -107,11 +107,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteRepositoryManifest(string registryName, string repositoryName, string manifestDigest) {
             var parameters = new List<Parameter> {
-                new Parameter(nameof(registryName), registryName, ParameterType.UrlSegment),
-                new Parameter(nameof(repositoryName), repositoryName, ParameterType.UrlSegment),
+                new UrlSegmentParameter (nameof(registryName), registryName),
+                new UrlSegmentParameter (nameof(repositoryName), repositoryName),
             };
 
-            return _connection.ExecuteRaw($"registry/{{{nameof(registryName)}}}/repositories/{{{nameof(repositoryName)}}}/digests/{manifestDigest}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw($"registry/{{{nameof(registryName)}}}/repositories/{{{nameof(repositoryName)}}}/digests/{manifestDigest}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -119,10 +119,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<GarbageCollection> StartGarbageCollection(string registryName) {
             var parameters = new List<Parameter> {
-                new Parameter(nameof(registryName), registryName, ParameterType.UrlSegment),
+                new UrlSegmentParameter (nameof(registryName), registryName),
             };
 
-            return _connection.ExecuteRequest<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collection", parameters, null, "garbage_collections", Method.POST);
+            return _connection.ExecuteRequest<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collection", parameters, null, "garbage_collections", Method.Post);
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<GarbageCollection> GetActiveGarbageCollection(string registryName) {
             var parameters = new List<Parameter> {
-                new Parameter(nameof(registryName), registryName, ParameterType.UrlSegment),
+                new UrlSegmentParameter (nameof(registryName), registryName),
             };
 
             return _connection.ExecuteRequest<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collection", parameters, null, "garbage_collections");
@@ -141,7 +141,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<GarbageCollection>> GetAllGarbageCollections(string registryName) {
             var parameters = new List<Parameter> {
-                new Parameter(nameof(registryName), registryName, ParameterType.UrlSegment),
+                new UrlSegmentParameter (nameof(registryName), registryName),
             };
 
             return _connection.GetPaginated<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collections", parameters, "garbage_collections");
@@ -152,11 +152,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<GarbageCollection> UpdateGarbageCollection(string registryName, string uuid, UpdateGarbageCollection updateGarbageCollection) {
             var parameters = new List<Parameter> {
-                new Parameter(nameof(registryName), registryName, ParameterType.UrlSegment),
-                new Parameter(nameof(uuid), uuid, ParameterType.UrlSegment),
+                new UrlSegmentParameter (nameof(registryName), registryName),
+                new UrlSegmentParameter (nameof(uuid), uuid),
             };
 
-            return _connection.ExecuteRequest<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collection/{{{nameof(uuid)}}}", parameters, updateGarbageCollection, "garbage_collections", Method.PUT);
+            return _connection.ExecuteRequest<GarbageCollection>($"registry/{{{nameof(registryName)}}}/garbage-collection/{{{nameof(uuid)}}}", parameters, updateGarbageCollection, "garbage_collections", Method.Put);
         }
 
         /// <summary>

--- a/DigitalOcean.API/Clients/DatabasesClient.cs
+++ b/DigitalOcean.API/Clients/DatabasesClient.cs
@@ -19,9 +19,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<ConnectionPool> AddConnectionPool(string databaseId, Models.Requests.ConnectionPool pool) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
-            return _connection.ExecuteRequest<ConnectionPool>("databases/{id}/pools", parameters, pool, "pool", Method.POST);
+            return _connection.ExecuteRequest<ConnectionPool>("databases/{id}/pools", parameters, pool, "pool", Method.Post);
         }
 
         /// <summary>
@@ -29,9 +29,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Database> AddDatabase(string databaseId, Models.Requests.Database database) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
-            return _connection.ExecuteRequest<Database>("databases/{id}/dbs", parameters, database, "db", Method.POST);
+            return _connection.ExecuteRequest<Database>("databases/{id}/dbs", parameters, database, "db", Method.Post);
         }
 
         /// <summary>
@@ -39,16 +39,16 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseUser> AddUser(string databaseId, Models.Requests.DatabaseUser user) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
-            return _connection.ExecuteRequest<DatabaseUser>("databases/{id}/users", parameters, user, "user", Method.POST);
+            return _connection.ExecuteRequest<DatabaseUser>("databases/{id}/users", parameters, user, "user", Method.Post);
         }
 
         /// <summary>
         /// Create a database cluster
         /// </summary>
         public Task<DatabaseCluster> Create(Models.Requests.DatabaseCluster database) {
-            return _connection.ExecuteRequest<DatabaseCluster>("databases", null, database, "database", Method.POST);
+            return _connection.ExecuteRequest<DatabaseCluster>("databases", null, database, "database", Method.Post);
         }
 
         /// <summary>
@@ -56,9 +56,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseReplica> CreateReplica(string databaseId, Models.Requests.DatabaseReplica replica) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
-            return _connection.ExecuteRequest<DatabaseReplica>("databases/{id}/replicas", parameters, replica, "replica", Method.POST);
+            return _connection.ExecuteRequest<DatabaseReplica>("databases/{id}/replicas", parameters, replica, "replica", Method.Post);
         }
 
         /// <summary>
@@ -66,9 +66,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
-            return _connection.ExecuteRaw("databases/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("databases/{id}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -76,10 +76,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteConnectionPool(string databaseId, string poolName) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment),
-                new Parameter("name", poolName, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId),
+                new UrlSegmentParameter("name", poolName)
             };
-            return _connection.ExecuteRaw("databases/{id}/pools/{name}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("databases/{id}/pools/{name}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -87,10 +87,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteDatabase(string databaseId, string databaseName) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment),
-                new Parameter("name", databaseName, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId),
+                new UrlSegmentParameter("name", databaseName)
             };
-            return _connection.ExecuteRaw("databases/{id}/dbs/{name}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("databases/{id}/dbs/{name}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -98,10 +98,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteReplica(string databaseId, string replicaName) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment),
-                new Parameter("name", replicaName, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId),
+                new UrlSegmentParameter("name", replicaName)
             };
-            return _connection.ExecuteRaw("databases/{id}/replicas/{name}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("databases/{id}/replicas/{name}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseCluster> Get(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
             return _connection.ExecuteRequest<DatabaseCluster>("databases/{id}", parameters, null, "database");
         }
@@ -126,7 +126,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<DatabaseCluster>> GetAllByTag(string tag) {
             var parameters = new List<Parameter> {
-                new Parameter("tag_name", tag, ParameterType.QueryString)
+                new QueryParameter("tag_name", tag)
             };
             return _connection.GetPaginated<DatabaseCluster>("databases", parameters, "databases");
         }
@@ -136,7 +136,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<DatabaseReplica>> GetAllReplicas(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
             return _connection.GetPaginated<DatabaseReplica>("databases/{id}/replicas", parameters, "replicas");
         }
@@ -146,7 +146,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ConnectionPool>> GetAllConnectionPools(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
             return _connection.GetPaginated<ConnectionPool>("databases/{id}/pools", parameters, "pools");
         }
@@ -156,7 +156,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Database>> GetAllDatabases(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
             return _connection.GetPaginated<Database>("databases/{id}/dbs", parameters, "dbs");
         }
@@ -166,7 +166,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<DatabaseUser>> GetAllUsers(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
             return _connection.GetPaginated<DatabaseUser>("databases/{id}/users", parameters, "users");
         }
@@ -176,7 +176,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<DatabaseBackup>> GetBackups(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
             return _connection.GetPaginated<DatabaseBackup>("databases/{id}/backups", parameters, "backups");
         }
@@ -186,8 +186,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<ConnectionPool> GetConnectionPool(string databaseId, string poolName) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment),
-                new Parameter("name", poolName, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId),
+                new UrlSegmentParameter("name", poolName)
             };
             return _connection.ExecuteRequest<ConnectionPool>("databases/{id}/pools/{name}", parameters, null, "pool");
         }
@@ -197,8 +197,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Database> GetDatabase(string databaseId, string databaseName) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment),
-                new Parameter("name", databaseName, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId),
+                new UrlSegmentParameter("name", databaseName)
             };
             return _connection.ExecuteRequest<Database>("databases/{id}/dbs/{name}", parameters, null, "db");
         }
@@ -208,8 +208,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseReplica> GetReplica(string databaseId, string replicaName) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment),
-                new Parameter("name", replicaName, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId),
+                new UrlSegmentParameter("name", replicaName)
             };
             return _connection.ExecuteRequest<DatabaseReplica>("databases/{id}/replicas/{name}", parameters, null, "replica");
         }
@@ -219,8 +219,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseUser> GetUser(string databaseId, string username) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment),
-                new Parameter("name", username, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId),
+                new UrlSegmentParameter("name", username)
             };
             return _connection.ExecuteRequest<DatabaseUser>("databases/{id}/users/{name}", parameters, null, "user");
         }
@@ -230,9 +230,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Maintenance(string databaseId, Models.Requests.MaintenanceWindow window) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
-            return _connection.ExecuteRaw("databases/{id}/maintenance", parameters, window, Method.POST);
+            return _connection.ExecuteRaw("databases/{id}/maintenance", parameters, window, Method.Post);
         }
 
         /// <summary>
@@ -240,9 +240,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Migrate(string databaseId, Models.Requests.MigrateDatabase migrate) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
-            return _connection.ExecuteRaw("databases/{id}/migrate", parameters, migrate, Method.POST);
+            return _connection.ExecuteRaw("databases/{id}/migrate", parameters, migrate, Method.Post);
         }
 
         /// <summary>
@@ -250,10 +250,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task RemoveUser(string databaseId, string username) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment),
-                new Parameter("name", username, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId),
+                new UrlSegmentParameter("name", username)
             };
-            return _connection.ExecuteRaw("databases/{id}/users/{name}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("databases/{id}/users/{name}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -262,10 +262,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DatabaseUser> ResetUserAuth(string databaseId, string username, Models.Requests.DatabaseResetUserAuth resetAuth) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment),
-                new Parameter("username", username, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId),
+                new UrlSegmentParameter("username", username)
             };
-            return _connection.ExecuteRequest<DatabaseUser>("databases/{id}/users/{username}/reset_auth", parameters, resetAuth, "user", Method.POST);
+            return _connection.ExecuteRequest<DatabaseUser>("databases/{id}/users/{username}/reset_auth", parameters, resetAuth, "user", Method.Post);
         }
 
         /// <summary>
@@ -273,16 +273,16 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Resize(string databaseId, Models.Requests.ResizeDatabase resize) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
-            return _connection.ExecuteRaw("databases/{id}/resize", parameters, resize, Method.POST);
+            return _connection.ExecuteRaw("databases/{id}/resize", parameters, resize, Method.Post);
         }
 
         /// <summary>
         /// Create a new database cluster based on a backup of an existing cluster
         /// </summary>
         public Task<DatabaseCluster> Restore(Models.Requests.DatabaseBackup backup) {
-            return _connection.ExecuteRequest<DatabaseCluster>("databases", null, backup, "database", Method.POST);
+            return _connection.ExecuteRequest<DatabaseCluster>("databases", null, backup, "database", Method.Post);
         }
 
         /// <summary>
@@ -293,9 +293,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task UpdateFirewallRules(string databaseId, Models.Requests.UpdateDatabaseFirewallRules updateRules) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
-            return _connection.ExecuteRaw("databases/{id}/firewall", parameters, updateRules, Method.PUT);
+            return _connection.ExecuteRaw("databases/{id}/firewall", parameters, updateRules, Method.Put);
         }
 
         /// <summary>
@@ -303,7 +303,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<DatabaseFirewallRule>> ListFirewallRules(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
             return _connection.GetPaginated<DatabaseFirewallRule>("databases/{id}/firewall", parameters, "rules");
         }
@@ -313,7 +313,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<RedisEvictionPolicy> RetrieveEvictionPolicy(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", databaseId)
             };
             return _connection.ExecuteRequest<RedisEvictionPolicy>("databases/{id}/eviction_policy", parameters, null, null);
         }
@@ -323,9 +323,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task ConfigureEvictionPolicy(string databaseId, Models.Requests.RedisEvictionPolicy evictionPolicy) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", databaseId)
             };
-            return _connection.ExecuteRaw("databases/{id}/eviction_policy", parameters, evictionPolicy, Method.PUT);
+            return _connection.ExecuteRaw("databases/{id}/eviction_policy", parameters, evictionPolicy, Method.Put);
         }
 
         /// <summary>
@@ -333,7 +333,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<MySqlModes> RetrieveSqlModes(string databaseId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", databaseId)
             };
             return _connection.ExecuteRequest<MySqlModes>("databases/{id}/sql_mode", parameters, null, null);
         }
@@ -344,9 +344,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task ConfigureSqlModes(string databaseId, Models.Requests.MySqlModes sqlModes) {
             var parameters = new List<Parameter> {
-                new Parameter("id", databaseId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", databaseId)
             };
-            return _connection.ExecuteRaw("databases/{id}/sql_mode", parameters, sqlModes, Method.PUT);
+            return _connection.ExecuteRaw("databases/{id}/sql_mode", parameters, sqlModes, Method.Put);
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/DomainRecordsClient.cs
+++ b/DigitalOcean.API/Clients/DomainRecordsClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -20,7 +20,7 @@ namespace DigitalOcean.API.Clients {
         public Task<IReadOnlyList<DomainRecord>> GetAll(string domainName) {
             // docs don't say this is paginated? but it could be so run it thru that anyway
             var parameters = new List<Parameter> {
-                new Parameter("name", domainName, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", domainName)
             };
             return _connection.GetPaginated<DomainRecord>("domains/{name}/records", parameters, "domain_records");
         }
@@ -30,10 +30,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DomainRecord> Create(string domainName, Models.Requests.DomainRecord record) {
             var parameters = new List<Parameter> {
-                new Parameter("name", domainName, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", domainName)
             };
             return _connection.ExecuteRequest<DomainRecord>("domains/{name}/records", parameters, record,
-                "domain_record", Method.POST);
+                "domain_record", Method.Post);
         }
 
         /// <summary>
@@ -41,8 +41,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DomainRecord> Get(string domainName, long recordId) {
             var parameters = new List<Parameter> {
-                new Parameter("name", domainName, ParameterType.UrlSegment),
-                new Parameter("id", recordId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", domainName),
+                new UrlSegmentParameter ("id", recordId.ToString())
             };
             return _connection.ExecuteRequest<DomainRecord>("domains/{name}/records/{id}", parameters, null, "domain_record");
         }
@@ -52,10 +52,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string domainName, long recordId) {
             var parameters = new List<Parameter> {
-                new Parameter("name", domainName, ParameterType.UrlSegment),
-                new Parameter("id", recordId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", domainName),
+                new UrlSegmentParameter ("id", recordId.ToString())
             };
-            return _connection.ExecuteRaw("domains/{name}/records/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("domains/{name}/records/{id}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -63,11 +63,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<DomainRecord> Update(string domainName, long recordId, Models.Requests.UpdateDomainRecord updateRecord) {
             var parameters = new List<Parameter> {
-                new Parameter("name", domainName, ParameterType.UrlSegment),
-                new Parameter("id", recordId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", domainName),
+                new UrlSegmentParameter ("id", recordId.ToString())
             };
             return _connection.ExecuteRequest<DomainRecord>("domains/{name}/records/{id}", parameters, updateRecord,
-                "domain_record", Method.PUT);
+                "domain_record", Method.Put);
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/DomainsClient.cs
+++ b/DigitalOcean.API/Clients/DomainsClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
@@ -26,7 +26,7 @@ namespace DigitalOcean.API.Clients {
         /// Create a new domain
         /// </summary>
         public Task<Domain> Create(Models.Requests.Domain domain) {
-            return _connection.ExecuteRequest<Domain>("domains", null, domain, "domain", Method.POST);
+            return _connection.ExecuteRequest<Domain>("domains", null, domain, "domain", Method.Post);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Domain> Get(string domainName) {
             var parameters = new List<Parameter> {
-                new Parameter("name", domainName, ParameterType.UrlSegment)
+                new UrlSegmentParameter("name", domainName)
             };
             return _connection.ExecuteRequest<Domain>("domains/{name}", parameters, null, "domain");
         }
@@ -44,9 +44,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string domainName) {
             var parameters = new List<Parameter> {
-                new Parameter("name", domainName, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", domainName)
             };
-            return _connection.ExecuteRaw("domains/{name}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("domains/{name}", parameters, null, Method.Delete);
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/DropletActionsClient.cs
+++ b/DigitalOcean.API/Clients/DropletActionsClient.cs
@@ -20,11 +20,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Reboot(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "reboot" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -32,11 +32,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> PowerCycle(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "power_cycle" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -44,11 +44,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Shutdown(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "shutdown" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -56,11 +56,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> PowerOff(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "power_off" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -68,11 +68,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> PowerOn(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "power_on" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -80,11 +80,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> ResetPassword(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "password_reset" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Resize(long dropletId, string sizeSlug, bool resizeDisk) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction {
                 Type = "resize",
@@ -100,7 +100,7 @@ namespace DigitalOcean.API.Clients {
                 Disk = resizeDisk
             };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -110,14 +110,14 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Restore(long dropletId, object imageIdOrSlug) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction {
                 Type = "restore",
                 Image = imageIdOrSlug
             };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -125,14 +125,14 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Rebuild(long dropletId, object imageIdOrSlug) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction {
                 Type = "rebuild",
                 Image = imageIdOrSlug
             };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -140,14 +140,14 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Rename(long dropletId, string name) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction {
                 Type = "rename",
                 Name = name
             };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -155,14 +155,14 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> ChangeKernel(long dropletId, long kernelId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction {
                 Type = "change_kernel",
                 KernelId = kernelId
             };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -170,11 +170,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> EnableIpv6(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "enable_ipv6" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -182,11 +182,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> EnableBackups(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "enable_backups" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -194,11 +194,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> DisableBackups(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "disable_backups" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -206,11 +206,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> EnablePrivateNetworking(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction { Type = "enable_private_networking" };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -218,14 +218,14 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Snapshot(long dropletId, string name) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString())
             };
             var body = new Models.Requests.DropletAction {
                 Type = "snapshot",
                 Name = name
             };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions", parameters, body,
-                "action", Method.POST);
+                "action", Method.Post);
         }
 
         /// <summary>
@@ -233,8 +233,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> GetDropletAction(long dropletId, long actionId) {
             var parameters = new List<Parameter> {
-                new Parameter("dropletId", dropletId.ToString(), ParameterType.UrlSegment),
-                new Parameter("actionId", actionId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("dropletId", dropletId.ToString()),
+                new UrlSegmentParameter ("actionId", actionId.ToString())
             };
             return _connection.ExecuteRequest<Action>("droplets/{dropletId}/actions/{actionId}", parameters,
                 null, "action");
@@ -255,11 +255,11 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Action>> ActionOnTag(string tag, string actionType) {
             var parameters = new List<Parameter> {
-                new Parameter("tag_name", tag, ParameterType.QueryString)
+                new QueryParameter("tag_name", tag)
             };
             var body = new Models.Requests.DropletAction { Type = actionType };
             return _connection.ExecuteRequest<List<Action>>("droplets/actions", parameters, body,
-                "actions", Method.POST)
+                "actions", Method.Post)
                 .ToReadOnlyListAsync();
         }
 

--- a/DigitalOcean.API/Clients/DropletsClient.cs
+++ b/DigitalOcean.API/Clients/DropletsClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Extensions;
 using DigitalOcean.API.Http;
@@ -27,7 +27,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Droplet>> GetAllByTag(string tagName) {
             var parameters = new List<Parameter> {
-                new Parameter("tag_name", tagName, ParameterType.QueryString)
+                new QueryParameter("tag_name", tagName)
             };
 
             return _connection.GetPaginated<Droplet>("droplets", parameters, "droplets");
@@ -38,7 +38,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Droplet>> GetAllNeighbors(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", dropletId.ToString())
             };
 
             return _connection.GetPaginated<Droplet>("droplets/{id}/neighbors", parameters, "droplets");
@@ -49,7 +49,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Kernel>> GetKernels(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", dropletId.ToString())
             };
             return _connection.GetPaginated<Kernel>("droplets/{id}/kernels", parameters, "kernels");
         }
@@ -59,7 +59,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Image>> GetSnapshots(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", dropletId.ToString())
             };
             return _connection.GetPaginated<Image>("droplets/{id}/snapshots", parameters, "snapshots");
         }
@@ -69,7 +69,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Image>> GetBackups(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", dropletId.ToString())
             };
             return _connection.GetPaginated<Image>("droplets/{id}/backups", parameters, "backups");
         }
@@ -79,7 +79,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Action>> GetActions(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", dropletId.ToString())
             };
             return _connection.GetPaginated<Action>("droplets/{id}/actions", parameters, "actions");
         }
@@ -88,7 +88,7 @@ namespace DigitalOcean.API.Clients {
         /// Create a new Droplet
         /// </summary>
         public Task<Droplet> Create(Models.Requests.Droplet droplet) {
-            return _connection.ExecuteRequest<Droplet>("droplets", null, droplet, "droplet", Method.POST);
+            return _connection.ExecuteRequest<Droplet>("droplets", null, droplet, "droplet", Method.Post);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace DigitalOcean.API.Clients {
         /// Up to ten Droplets may be created at a time.
         /// </summary>
         public Task<IReadOnlyList<Droplet>> Create(Models.Requests.Droplets droplets) {
-            return _connection.ExecuteRequest<List<Droplet>>("droplets", null, droplets, "droplets", Method.POST)
+            return _connection.ExecuteRequest<List<Droplet>>("droplets", null, droplets, "droplets", Method.Post)
                 .ToReadOnlyListAsync();
         }
 
@@ -106,7 +106,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Droplet> Get(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", dropletId.ToString())
             };
             return _connection.ExecuteRequest<Droplet>("droplets/{id}", parameters, null, "droplet");
         }
@@ -116,9 +116,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", dropletId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", dropletId.ToString())
             };
-            return _connection.ExecuteRaw("droplets/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("droplets/{id}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -126,9 +126,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteByTag(string tagName) {
             var parameters = new List<Parameter> {
-                new Parameter("tag_name", tagName, ParameterType.QueryString)
+                new QueryParameter("tag_name", tagName)
             };
-            return _connection.ExecuteRaw("droplets", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("droplets", parameters, null, Method.Delete);
         }
 
         /// <summary>

--- a/DigitalOcean.API/Clients/FirewallsClient.cs
+++ b/DigitalOcean.API/Clients/FirewallsClient.cs
@@ -17,9 +17,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task AddDroplets(string firewallId, Models.Requests.FirewallDroplets droplets) {
             var parameters = new List<Parameter> {
-                new Parameter("id", firewallId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", firewallId)
             };
-            return _connection.ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.POST);
+            return _connection.ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.Post);
         }
 
         /// <summary>
@@ -27,9 +27,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task AddRules(string firewallId, Models.Requests.FirewallRules rules) {
             var parameters = new List<Parameter> {
-                new Parameter("id", firewallId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", firewallId)
             };
-            return _connection.ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.POST);
+            return _connection.ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.Post);
         }
 
         /// <summary>
@@ -37,16 +37,16 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task AddTags(string firewallId, Models.Requests.FirewallTags tags) {
             var parameters = new List<Parameter> {
-                new Parameter("id", firewallId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", firewallId)
             };
-            return _connection.ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.POST);
+            return _connection.ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.Post);
         }
 
         /// <summary>
         /// Create a new Cloud Firewall
         /// </summary>
         public Task<Firewall> Create(Models.Requests.Firewall firewall) {
-            return _connection.ExecuteRequest<Firewall>("firewalls", null, firewall, "firewall", Method.POST);
+            return _connection.ExecuteRequest<Firewall>("firewalls", null, firewall, "firewall", Method.Post);
         }
 
         /// <summary>
@@ -54,9 +54,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string firewallId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", firewallId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", firewallId)
             };
-            return _connection.ExecuteRaw("firewalls/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("firewalls/{id}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Firewall> Get(string firewallId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", firewallId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", firewallId)
             };
             return _connection.ExecuteRequest<Firewall>("firewalls/{id}", parameters, null, "firewall");
         }
@@ -81,9 +81,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task RemoveDroplets(string firewallId, Models.Requests.FirewallDroplets droplets) {
             var parameters = new List<Parameter> {
-                new Parameter("id", firewallId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", firewallId)
             };
-            return _connection.ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.DELETE);
+            return _connection.ExecuteRaw("firewalls/{id}/droplets", parameters, droplets, Method.Delete);
         }
 
         /// <summary>
@@ -91,9 +91,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task RemoveRules(string firewallId, Models.Requests.FirewallRules rules) {
             var parameters = new List<Parameter> {
-                new Parameter("id", firewallId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", firewallId)
             };
-            return _connection.ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.DELETE);
+            return _connection.ExecuteRaw("firewalls/{id}/rules", parameters, rules, Method.Delete);
         }
 
         /// <summary>
@@ -101,9 +101,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task RemoveTags(string firewallId, Models.Requests.FirewallTags tags) {
             var parameters = new List<Parameter> {
-                new Parameter("id", firewallId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", firewallId)
             };
-            return _connection.ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.DELETE);
+            return _connection.ExecuteRaw("firewalls/{id}/tags", parameters, tags, Method.Delete);
         }
 
         /// <summary>
@@ -111,9 +111,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Firewall> Update(string firewallId, Models.Requests.Firewall firewall) {
             var parameters = new List<Parameter> {
-                new Parameter("id", firewallId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", firewallId)
             };
-            return _connection.ExecuteRequest<Firewall>("firewalls/{id}", parameters, firewall, "firewall", Method.PUT);
+            return _connection.ExecuteRequest<Firewall>("firewalls/{id}", parameters, firewall, "firewall", Method.Put);
         }
     }
 }

--- a/DigitalOcean.API/Clients/FloatingIpActionsClient.cs
+++ b/DigitalOcean.API/Clients/FloatingIpActionsClient.cs
@@ -17,13 +17,13 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Assign(string ipAddress, long dropletId) {
             var parameters = new List<Parameter> {
-                new Parameter("ip", ipAddress, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("ip", ipAddress)
             };
             var body = new Models.Requests.FloatingIpAction {
                 Type = "assign",
                 DropletId = dropletId
             };
-            return _connection.ExecuteRequest<Action>("floating_ips/{ip}/actions", parameters, body, "action", Method.POST);
+            return _connection.ExecuteRequest<Action>("floating_ips/{ip}/actions", parameters, body, "action", Method.Post);
         }
 
         /// <summary>
@@ -31,8 +31,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> GetAction(string ipAddress, long actionId) {
             var parameters = new List<Parameter> {
-                new Parameter("ip", ipAddress, ParameterType.UrlSegment),
-                new Parameter("actionId", actionId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("ip", ipAddress),
+                new UrlSegmentParameter ("actionId", actionId.ToString())
             };
             return _connection.ExecuteRequest<Action>("floating_ips/{ip}/actions/{actionId}", parameters, null, "action");
         }
@@ -42,7 +42,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Action>> GetActions(string ipAddress) {
             var parameters = new List<Parameter> {
-                new Parameter("ip", ipAddress, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("ip", ipAddress)
             };
             return _connection.GetPaginated<Action>("floating_ips/{ip}/actions", parameters, "actions");
         }
@@ -52,12 +52,12 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Unassign(string ipAddress) {
             var parameters = new List<Parameter> {
-                new Parameter("ip", ipAddress, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("ip", ipAddress)
             };
             var body = new Models.Requests.FloatingIpAction {
                 Type = "unassign"
             };
-            return _connection.ExecuteRequest<Action>("floating_ips/{ip}/actions", parameters, body, "action", Method.POST);
+            return _connection.ExecuteRequest<Action>("floating_ips/{ip}/actions", parameters, body, "action", Method.Post);
         }
     }
 }

--- a/DigitalOcean.API/Clients/FloatingIpsClient.cs
+++ b/DigitalOcean.API/Clients/FloatingIpsClient.cs
@@ -16,7 +16,7 @@ namespace DigitalOcean.API.Clients {
         /// A Floating IP must be either assigned to a Droplet or reserved to a region
         /// </summary>
         public Task<FloatingIp> Create(Models.Requests.FloatingIp floatingIp) {
-            return _connection.ExecuteRequest<FloatingIp>("floating_ips", null, floatingIp, "floating_ip", Method.POST);
+            return _connection.ExecuteRequest<FloatingIp>("floating_ips", null, floatingIp, "floating_ip", Method.Post);
         }
 
         /// <summary>
@@ -24,9 +24,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string ipAddress) {
             var parameters = new List<Parameter> {
-                new Parameter("ip", ipAddress, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("ip", ipAddress)
             };
-            return _connection.ExecuteRaw("floating_ips/{ip}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("floating_ips/{ip}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<FloatingIp> Get(string ipAddress) {
             var parameters = new List<Parameter> {
-                new Parameter("ip", ipAddress, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("ip", ipAddress)
             };
             return _connection.ExecuteRequest<FloatingIp>("floating_ips/{ip}", parameters, null, "floating_ip");
         }

--- a/DigitalOcean.API/Clients/ImageActionsClient.cs
+++ b/DigitalOcean.API/Clients/ImageActionsClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -19,7 +19,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Transfer(long imageId, string regionSlug) {
             var parameters = new List<Parameter> {
-                new Parameter("imageId", imageId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter("imageId", imageId.ToString())
             };
 
             var body = new Models.Requests.ImageAction {
@@ -28,7 +28,7 @@ namespace DigitalOcean.API.Clients {
             };
 
             return _connection.ExecuteRequest<Action>("images/{imageId}/actions", parameters, body, "action",
-                Method.POST);
+                Method.Post);
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Convert(long imageId) {
             var parameters = new List<Parameter> {
-                new Parameter("imageId", imageId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("imageId", imageId.ToString())
             };
 
             var body = new Models.Requests.ImageAction {
@@ -44,7 +44,7 @@ namespace DigitalOcean.API.Clients {
             };
 
             return _connection.ExecuteRequest<Action>("images/{imageId}/actions", parameters, body, "action",
-                Method.POST);
+                Method.Post);
         }
 
         /// <summary>
@@ -52,8 +52,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> GetAction(long imageId, long actionId) {
             var parameters = new List<Parameter> {
-                new Parameter("imageId", imageId.ToString(), ParameterType.UrlSegment),
-                new Parameter("actionId", actionId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("imageId", imageId.ToString()),
+                new UrlSegmentParameter ("actionId", actionId.ToString())
             };
             return _connection.ExecuteRequest<Action>("images/{imageId}/actions/{actionId}", parameters, null, "action");
         }

--- a/DigitalOcean.API/Clients/ImagesClient.cs
+++ b/DigitalOcean.API/Clients/ImagesClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
@@ -45,7 +45,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Image>> GetAllByTag(string tag) {
             var parameters = new List<Parameter> {
-                new Parameter("tag_name", tag, ParameterType.QueryString)
+                new QueryParameter("tag_name", tag)
             };
             return _connection.GetPaginated<Image>("images", parameters, "images");
         }
@@ -55,7 +55,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Action>> GetAllActions(long imageId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", imageId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", imageId.ToString())
             };
             return _connection.GetPaginated<Action>("images/{id}/actions", parameters, "actions");
         }
@@ -66,7 +66,7 @@ namespace DigitalOcean.API.Clients {
         /// It may be compressed using gzip or bzip2 and must be smaller than 100 GB after being decompressed.
         /// </summary>
         public Task<Image> Create(Models.Requests.Image image) {
-            return _connection.ExecuteRequest<Image>("images", null, image, "image", Method.POST);
+            return _connection.ExecuteRequest<Image>("images", null, image, "image", Method.Post);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace DigitalOcean.API.Clients {
         /// </remarks>
         public Task<Image> Get(object imageIdOrSlug) {
             var parameters = new List<Parameter> {
-                new Parameter("id", imageIdOrSlug, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", imageIdOrSlug.ToString())
             };
             return _connection.ExecuteRequest<Image>("images/{id}", parameters, null, "image");
         }
@@ -87,9 +87,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(long imageId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", imageId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", imageId.ToString())
             };
-            return _connection.ExecuteRaw("images/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("images/{id}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -97,9 +97,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Image> Update(long imageId, Models.Requests.UpdateImage updateImage) {
             var parameters = new List<Parameter> {
-                new Parameter("id", imageId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", imageId.ToString())
             };
-            return _connection.ExecuteRequest<Image>("images/{id}", parameters, updateImage, "image", Method.PUT);
+            return _connection.ExecuteRequest<Image>("images/{id}", parameters, updateImage, "image", Method.Put);
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/KeysClient.cs
+++ b/DigitalOcean.API/Clients/KeysClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -25,7 +25,7 @@ namespace DigitalOcean.API.Clients {
         /// Create a new key entry
         /// </summary>
         public Task<Key> Create(Models.Requests.Key key) {
-            return _connection.ExecuteRequest<Key>("account/keys", null, key, "ssh_key", Method.POST);
+            return _connection.ExecuteRequest<Key>("account/keys", null, key, "ssh_key", Method.Post);
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Key> Get(object keyIdOrFingerprint) {
             var parameters = new List<Parameter> {
-                new Parameter("id", keyIdOrFingerprint, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", keyIdOrFingerprint.ToString())
             };
             return _connection.ExecuteRequest<Key>("account/keys/{id}", parameters, null, "ssh_key");
         }
@@ -43,9 +43,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Key> Update(object keyIdOrFingerprint, Models.Requests.UpdateKey updateKey) {
             var parameters = new List<Parameter> {
-                new Parameter("id", keyIdOrFingerprint, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", keyIdOrFingerprint.ToString())
             };
-            return _connection.ExecuteRequest<Key>("account/keys/{id}", parameters, updateKey, "ssh_key", Method.PUT);
+            return _connection.ExecuteRequest<Key>("account/keys/{id}", parameters, updateKey, "ssh_key", Method.Put);
         }
 
         /// <summary>
@@ -53,9 +53,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(object keyIdOrFingerprint) {
             var parameters = new List<Parameter> {
-                new Parameter("id", keyIdOrFingerprint, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id",keyIdOrFingerprint.ToString())
             };
-            return _connection.ExecuteRaw("account/keys/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("account/keys/{id}", parameters, null, Method.Delete);
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/KubernetesClient.cs
+++ b/DigitalOcean.API/Clients/KubernetesClient.cs
@@ -21,16 +21,16 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesNodePool> AddNodePool(string clusterId, Models.Requests.KubernetesNodePool pool) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId)
             };
-            return _connection.ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools", parameters, pool, "node_pool", Method.POST);
+            return _connection.ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools", parameters, pool, "node_pool", Method.Post);
         }
 
         /// <summary>
         /// Create a new Kubernetes cluster
         /// </summary>
         public Task<KubernetesCluster> Create(Models.Requests.KubernetesCluster cluster) {
-            return _connection.ExecuteRequest<KubernetesCluster>("kubernetes/clusters", null, cluster, "kubernetes_cluster", Method.POST);
+            return _connection.ExecuteRequest<KubernetesCluster>("kubernetes/clusters", null, cluster, "kubernetes_cluster", Method.Post);
         }
 
         /// <summary>
@@ -38,9 +38,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string clusterId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId)
             };
-            return _connection.ExecuteRaw("kubernetes/clusters/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("kubernetes/clusters/{id}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -59,11 +59,11 @@ namespace DigitalOcean.API.Clients {
                     break;
             }
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment),
-                new Parameter("poolId", poolId, ParameterType.UrlSegment),
-                new Parameter("nodeId", nodeId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId),
+                new UrlSegmentParameter ("poolId", poolId),
+                new UrlSegmentParameter ("nodeId", nodeId)
             };
-            return _connection.ExecuteRaw(endpoint, parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw(endpoint, parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -71,10 +71,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteNodePool(string clusterId, string poolId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment),
-                new Parameter("poolId", poolId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId),
+                new UrlSegmentParameter("poolId", poolId)
             };
-            return _connection.ExecuteRaw("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesCluster> Get(string clusterId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId)
             };
             return _connection.ExecuteRequest<KubernetesCluster>("kubernetes/clusters/{id}", parameters, null, "kubernetes_cluster");
         }
@@ -99,7 +99,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<KubernetesNodePool>> GetAllNodePools(string clusterId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId)
             };
             return _connection.GetPaginated<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools", parameters, "node_pools");
         }
@@ -112,7 +112,7 @@ namespace DigitalOcean.API.Clients {
         /// </returns>
         public Task<IReadOnlyList<byte>> GetKubeConfig(string clusterId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId)
             };
             return _connection.ExecuteRaw("kubernetes/clusters/{id}/kubeconfig", parameters, null).ToByteArrayAsync();
         }
@@ -122,8 +122,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesNodePool> GetNodePool(string clusterId, string poolId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment),
-                new Parameter("poolId", poolId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId),
+                new UrlSegmentParameter ("poolId", poolId)
             };
             return _connection.ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, null, "node_pool");
         }
@@ -140,7 +140,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<KubernetesUpgrade>> GetUpgrades(string clusterId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId)
             };
             return _connection.ExecuteRequest<List<KubernetesUpgrade>>("kubernetes/clusters/{id}/upgrades", parameters, null, "available_upgrade_versions").ToReadOnlyListAsync();
         }
@@ -150,9 +150,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesCluster> Update(string clusterId, Models.Requests.UpdateKubernetesCluster cluster) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId)
             };
-            return _connection.ExecuteRequest<KubernetesCluster>("kubernetes/clusters/{id}", parameters, cluster, "kubernetes_cluster", Method.PUT);
+            return _connection.ExecuteRequest<KubernetesCluster>("kubernetes/clusters/{id}", parameters, cluster, "kubernetes_cluster", Method.Put);
         }
 
         /// <summary>
@@ -160,10 +160,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<KubernetesNodePool> UpdateNodePool(string clusterId, string poolId, Models.Requests.UpdateKubernetesNodePool pool) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment),
-                new Parameter("poolId", poolId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId),
+                new UrlSegmentParameter("poolId", poolId)
             };
-            return _connection.ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, pool, "node_pool", Method.PUT);
+            return _connection.ExecuteRequest<KubernetesNodePool>("kubernetes/clusters/{id}/node_pools/{poolId}", parameters, pool, "node_pool", Method.Put);
         }
 
         /// <summary>
@@ -171,9 +171,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Upgrade(string clusterId, Models.Requests.KubernetesUpgrade upgrade) {
             var parameters = new List<Parameter> {
-                new Parameter("id", clusterId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", clusterId)
             };
-            return _connection.ExecuteRaw("kubernetes/clusters/{id}/upgrade", parameters, upgrade, Method.POST);
+            return _connection.ExecuteRaw("kubernetes/clusters/{id}/upgrade", parameters, upgrade, Method.Post);
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/LoadBalancerClient.cs
+++ b/DigitalOcean.API/Clients/LoadBalancerClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -14,7 +14,7 @@ namespace DigitalOcean.API.Clients {
 
         public Task<LoadBalancer> Get(string loadBalancerId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", loadBalancerId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", loadBalancerId)
             };
             return _connection.ExecuteRequest<LoadBalancer>("load_balancers/{id}", parameters, null, "load_balancers");
         }
@@ -24,53 +24,53 @@ namespace DigitalOcean.API.Clients {
         }
 
         public Task<LoadBalancer> Create(Models.Requests.LoadBalancer loadBalancer) {
-            return _connection.ExecuteRequest<LoadBalancer>("load_balancers", null, loadBalancer, "load_balancers", Method.POST);
+            return _connection.ExecuteRequest<LoadBalancer>("load_balancers", null, loadBalancer, "load_balancers", Method.Post);
         }
 
         public Task Delete(string loadBalancerId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", loadBalancerId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", loadBalancerId)
             };
-            return _connection.ExecuteRaw("load_balancers/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("load_balancers/{id}", parameters, null, Method.Delete);
         }
 
         public Task Update(string loadBalancerId, Models.Requests.LoadBalancer loadBalancer) {
             var parameters = new List<Parameter> {
-                new Parameter("id", loadBalancerId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", loadBalancerId)
             };
-            return _connection.ExecuteRequest<LoadBalancer>("load_balancers/{id}", parameters, loadBalancer, "load_balancers", Method.PUT);
+            return _connection.ExecuteRequest<LoadBalancer>("load_balancers/{id}", parameters, loadBalancer, "load_balancers", Method.Put);
         }
 
         public Task AddDroplets(string loadBalancerId, Models.Requests.LoadBalancerDroplets dropletIds) {
             var parameters = new List<Parameter> {
-                new Parameter("id", loadBalancerId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", loadBalancerId)
             };
 
-            return _connection.ExecuteRaw("load_balancers/{id}/droplets", parameters, dropletIds, Method.POST);
+            return _connection.ExecuteRaw("load_balancers/{id}/droplets", parameters, dropletIds, Method.Post);
         }
 
         public Task RemoveDroplets(string loadBalancerId, Models.Requests.LoadBalancerDroplets dropletIds) {
             var parameters = new List<Parameter> {
-                new Parameter("id", loadBalancerId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", loadBalancerId)
             };
 
-            return _connection.ExecuteRaw("load_balancers/{id}/droplets", parameters, dropletIds, Method.DELETE);
+            return _connection.ExecuteRaw("load_balancers/{id}/droplets", parameters, dropletIds, Method.Delete);
         }
 
         public Task AddForwardingRules(string loadBalancerId, Models.Requests.ForwardingRulesList forwardingRules) {
             var parameters = new List<Parameter> {
-                new Parameter("id", loadBalancerId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", loadBalancerId)
             };
 
-            return _connection.ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, forwardingRules, Method.POST);
+            return _connection.ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, forwardingRules, Method.Post);
         }
 
         public Task RemoveForwardingRules(string loadBalancerId, Models.Requests.ForwardingRulesList forwardingRules) {
             var parameters = new List<Parameter> {
-                new Parameter("id", loadBalancerId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", loadBalancerId)
             };
 
-            return _connection.ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, forwardingRules, Method.DELETE);
+            return _connection.ExecuteRaw("load_balancers/{id}/forwarding_rules", parameters, forwardingRules, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API/Clients/ProjectResourcesClient.cs
+++ b/DigitalOcean.API/Clients/ProjectResourcesClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Extensions;
 using DigitalOcean.API.Http;
@@ -19,7 +19,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ProjectResource>> GetResources(string projectId) {
             var parameters = new List<Parameter> {
-                new Parameter("project_id", projectId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("project_id", projectId)
             };
             return _connection.GetPaginated<ProjectResource>("projects/{project_id}/resources", parameters, "resources");
         }
@@ -36,9 +36,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<ProjectResource>> AssignResources(string projectId, AssignResourceNames resources) {
             var parameters = new List<Parameter> {
-                new Parameter("project_id", projectId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("project_id", projectId)
             };
-            return _connection.ExecuteRequest<List<ProjectResource>>("projects/{project_id}/resources", parameters, resources, "resources", Method.POST)
+            return _connection.ExecuteRequest<List<ProjectResource>>("projects/{project_id}/resources", parameters, resources, "resources", Method.Post)
                 .ToReadOnlyListAsync();
         }
 
@@ -46,7 +46,7 @@ namespace DigitalOcean.API.Clients {
         /// To assign resources to the default project.
         /// </summary>
         public Task<IReadOnlyList<ProjectResource>> AssignDefaultResources(AssignResourceNames resources) {
-            return _connection.ExecuteRequest<List<ProjectResource>>("projects/default/resources", null, resources, "resources", Method.POST)
+            return _connection.ExecuteRequest<List<ProjectResource>>("projects/default/resources", null, resources, "resources", Method.Post)
                 .ToReadOnlyListAsync();
         }
     }

--- a/DigitalOcean.API/Clients/ProjectsClient.cs
+++ b/DigitalOcean.API/Clients/ProjectsClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
 using DigitalOcean.API.Models.Responses;
@@ -23,7 +23,7 @@ namespace DigitalOcean.API.Clients {
         /// To create a project.
         /// </summary>
         public Task<Project> Create(Models.Requests.Project project) {
-            return _connection.ExecuteRequest<Project>("projects", null, project, "project", Method.POST);
+            return _connection.ExecuteRequest<Project>("projects", null, project, "project", Method.Post);
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Project> Get(string projectId) {
             var parameters = new List<Parameter> {
-                new Parameter("project_id", projectId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("project_id", projectId)
             };
             return _connection.ExecuteRequest<Project>("projects/{project_id}", parameters, null, "project");
         }
@@ -48,9 +48,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Project> Update(string projectId, Models.Requests.UpdateProject updateProject) {
             var parameters = new List<Parameter> {
-                new Parameter("project_id", projectId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("project_id", projectId)
             };
-            return _connection.ExecuteRequest<Project>("projects/{project_id}", parameters, updateProject, "project", Method.PUT);
+            return _connection.ExecuteRequest<Project>("projects/{project_id}", parameters, updateProject, "project", Method.Put);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace DigitalOcean.API.Clients {
         public Task<Project> UpdateDefault(Models.Requests.UpdateProject updateProject) {
             // implied to always be true
             updateProject.IsDefault = true;
-            return _connection.ExecuteRequest<Project>("projects/default", null, updateProject, "project", Method.PUT);
+            return _connection.ExecuteRequest<Project>("projects/default", null, updateProject, "project", Method.Put);
         }
 
         /// <summary>
@@ -67,9 +67,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Project> Patch(string projectId, Models.Requests.PatchProject patchProject) {
             var parameters = new List<Parameter> {
-                new Parameter("project_id", projectId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("project_id", projectId)
             };
-            return _connection.ExecuteRequest<Project>("projects/{project_id}", parameters, patchProject, "project", Method.PATCH);
+            return _connection.ExecuteRequest<Project>("projects/{project_id}", parameters, patchProject, "project", Method.Patch);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace DigitalOcean.API.Clients {
         public Task<Project> PatchDefault(Models.Requests.PatchProject patchProject) {
             // implied to always be true
             patchProject.IsDefault = true;
-            return _connection.ExecuteRequest<Project>("projects/default", null, patchProject, "project", Method.PATCH);
+            return _connection.ExecuteRequest<Project>("projects/default", null, patchProject, "project", Method.Patch);
         }
 
         /// <summary>
@@ -87,9 +87,9 @@ namespace DigitalOcean.API.Clients {
         public Task Delete(string projectId)
         {
             var parameters = new List<Parameter> {
-                new Parameter("project_id", projectId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("project_id", projectId)
             };
-            return _connection.ExecuteRaw("projects/{project_id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("projects/{project_id}", parameters, null, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API/Clients/SnapshotsClient.cs
+++ b/DigitalOcean.API/Clients/SnapshotsClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DigitalOcean.API.Http;
@@ -39,7 +39,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Snapshot> Get(string snapshotId) {
             var parameters = new List<Parameter> {
-                new Parameter("snapshot_id", snapshotId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("snapshot_id", snapshotId)
             };
             return _connection.ExecuteRequest<Snapshot>("snapshots/{snapshot_id}", parameters, null, "snapshot");
         }
@@ -49,9 +49,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string snapshotId) {
             var parameters = new List<Parameter> {
-                new Parameter("snapshot_id", snapshotId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("snapshot_id", snapshotId)
             };
-            return _connection.ExecuteRaw("snapshots/{snapshot_id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("snapshots/{snapshot_id}", parameters, null, Method.Delete);
         }
     }
 }

--- a/DigitalOcean.API/Clients/TagsClient.cs
+++ b/DigitalOcean.API/Clients/TagsClient.cs
@@ -26,7 +26,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Tag> Get(string tagName) {
             var parameters = new List<Parameter> {
-                new Parameter("name", tagName, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", tagName)
             };
             return _connection.ExecuteRequest<Tag>("tags/{name}", parameters, null, "tag");
         }
@@ -39,7 +39,7 @@ namespace DigitalOcean.API.Clients {
                 Name = tagName
             };
 
-            return _connection.ExecuteRequest<Tag>("tags", null, data, "tag", Method.POST);
+            return _connection.ExecuteRequest<Tag>("tags", null, data, "tag", Method.Post);
         }
 
         /// <summary>
@@ -47,10 +47,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Tag(string tagName, Models.Requests.TagResources resources) {
             var parameters = new List<Parameter> {
-                new Parameter("name", tagName, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", tagName)
             };
 
-            return _connection.ExecuteRaw("tags/{name}/resources", parameters, resources, Method.POST);
+            return _connection.ExecuteRaw("tags/{name}/resources", parameters, resources, Method.Post);
         }
 
         /// <summary>
@@ -58,10 +58,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Untag(string tagName, Models.Requests.TagResources resources) {
             var parameters = new List<Parameter> {
-                new Parameter("name", tagName, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", tagName)
             };
 
-            return _connection.ExecuteRaw("tags/{name}/resources", parameters, resources, Method.DELETE);
+            return _connection.ExecuteRaw("tags/{name}/resources", parameters, resources, Method.Delete);
         }
 
         /// <summary>
@@ -69,9 +69,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string tagName) {
             var parameters = new List<Parameter> {
-                new Parameter("name", tagName, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("name", tagName)
             };
-            return _connection.ExecuteRaw("tags/{name}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("tags/{name}", parameters, null, Method.Delete);
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/VolumeActionsClient.cs
+++ b/DigitalOcean.API/Clients/VolumeActionsClient.cs
@@ -19,14 +19,14 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Attach(string volumeId, long dropletId, string volumeRegion) {
             var parameters = new List<Parameter> {
-                new Parameter("id", volumeId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", volumeId)
             };
             var body = new Models.Requests.VolumeAction {
                 Type = "attach",
                 DropletId = dropletId,
                 Region = volumeRegion
             };
-            return _connection.ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.POST);
+            return _connection.ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.Post);
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace DigitalOcean.API.Clients {
                 VolumeName = volumeName,
                 Region = volumeRegion
             };
-            return _connection.ExecuteRequest<Action>("volumes/actions", null, body, "action", Method.POST);
+            return _connection.ExecuteRequest<Action>("volumes/actions", null, body, "action", Method.Post);
         }
 
         /// <summary>
@@ -47,14 +47,14 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Detach(string volumeId, long dropletId, string volumeRegion) {
             var parameters = new List<Parameter> {
-                new Parameter("id", volumeId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", volumeId)
             };
             var body = new Models.Requests.VolumeAction {
                 Type = "detach",
                 DropletId = dropletId,
                 Region = volumeRegion
             };
-            return _connection.ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.POST);
+            return _connection.ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.Post);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace DigitalOcean.API.Clients {
                 VolumeName = volumeName,
                 Region = volumeRegion
             };
-            return _connection.ExecuteRequest<Action>("volumes/actions", null, body, "action", Method.POST);
+            return _connection.ExecuteRequest<Action>("volumes/actions", null, body, "action", Method.Post);
         }
 
         /// <summary>
@@ -75,8 +75,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> GetAction(string volumeId, long actionId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", volumeId, ParameterType.UrlSegment),
-                new Parameter("actionId", actionId.ToString(), ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", volumeId),
+                new UrlSegmentParameter("actionId", actionId.ToString())
             };
             return _connection.ExecuteRequest<Action>("volumes/{id}/actions/{actionId}", parameters, null, "action");
         }
@@ -86,7 +86,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Action>> GetActions(string volumeId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", volumeId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", volumeId)
             };
             return _connection.GetPaginated<Action>("volumes/{id}/actions", parameters, "action");
         }
@@ -96,14 +96,14 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Action> Resize(string volumeId, int sizeGigabytes, string volumeRegion) {
             var parameters = new List<Parameter> {
-                new Parameter("id", volumeId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", volumeId)
             };
             var body = new Models.Requests.VolumeAction {
                 Type = "resize",
                 SizeGigabytes = sizeGigabytes,
                 Region = volumeRegion
             };
-            return _connection.ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.POST);
+            return _connection.ExecuteRequest<Action>("volumes/{id}/actions", parameters, body, "action", Method.Post);
         }
 
         #endregion

--- a/DigitalOcean.API/Clients/VolumesClient.cs
+++ b/DigitalOcean.API/Clients/VolumesClient.cs
@@ -18,7 +18,7 @@ namespace DigitalOcean.API.Clients {
         /// Create a new Block Storage volume
         /// </summary>
         public Task<Volume> Create(Models.Requests.Volume volume) {
-            return _connection.ExecuteRequest<Volume>("volumes", null, volume, "volume", Method.POST);
+            return _connection.ExecuteRequest<Volume>("volumes", null, volume, "volume", Method.Post);
         }
 
         /// <summary>
@@ -26,9 +26,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Snapshot> CreateSnapshot(string volumeId, Models.Requests.VolumeSnapshot snapshot) {
             var parameters = new List<Parameter> {
-                new Parameter("id", volumeId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", volumeId)
             };
-            return _connection.ExecuteRequest<Snapshot>("volumes/{id}/snapshots", parameters, snapshot, "snapshot", Method.POST);
+            return _connection.ExecuteRequest<Snapshot>("volumes/{id}/snapshots", parameters, snapshot, "snapshot", Method.Post);
         }
 
         /// <summary>
@@ -36,9 +36,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string volumeId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", volumeId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", volumeId)
             };
-            return _connection.ExecuteRaw("volumes/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("volumes/{id}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -46,10 +46,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task DeleteByName(string name, string region) {
             var parameters = new List<Parameter> {
-                new Parameter("name", name, ParameterType.QueryString),
-                new Parameter("region", region, ParameterType.QueryString)
+                new QueryParameter("name", name),
+                new QueryParameter("region", region)
             };
-            return _connection.ExecuteRaw("volumes", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("volumes", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Volume> Get(string volumeId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", volumeId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", volumeId)
             };
             return _connection.ExecuteRequest<Volume>("volumes/{id}", parameters, null, "volume");
         }
@@ -74,8 +74,8 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Volume>> GetByName(string name, string region) {
             var parameters = new List<Parameter> {
-                new Parameter("name", name, ParameterType.QueryString),
-                new Parameter("region", region, ParameterType.QueryString)
+                new QueryParameter("name", name),
+                new QueryParameter("region", region)
             };
             return _connection.GetPaginated<Volume>("volumes", parameters, "volumes");
         }
@@ -85,7 +85,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<Snapshot>> GetSnapshots(string volumeId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", volumeId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", volumeId)
             };
             return _connection.GetPaginated<Snapshot>("volumes/{id}/snapshots", parameters, "snapshots");
         }

--- a/DigitalOcean.API/Clients/VpcClient.cs
+++ b/DigitalOcean.API/Clients/VpcClient.cs
@@ -24,7 +24,7 @@ namespace DigitalOcean.API.Clients {
         /// To create a VPC.
         /// </summary>
         public Task<Vpc> Create(Models.Requests.Vpc vpc) {
-            return _connection.ExecuteRequest<Vpc>("vpcs", null, vpc, "vpc", Method.POST);
+            return _connection.ExecuteRequest<Vpc>("vpcs", null, vpc, "vpc", Method.Post);
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Vpc> Get(string vpcId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", vpcId, ParameterType.UrlSegment)
+                new UrlSegmentParameter("id", vpcId)
             };
             return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, null, "vpc");
         }
@@ -45,9 +45,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task Delete(string vpcId) {
             var parameters = new List<Parameter> {
-                new Parameter("id", vpcId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", vpcId)
             };
-            return _connection.ExecuteRaw("vpcs/{id}", parameters, null, Method.DELETE);
+            return _connection.ExecuteRaw("vpcs/{id}", parameters, null, Method.Delete);
         }
 
         /// <summary>
@@ -57,9 +57,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Vpc> Update(string vpcId, Models.Requests.UpdateVpc updateVpc) {
             var parameters = new List<Parameter> {
-                new Parameter("id", vpcId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", vpcId)
             };
-            return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, updateVpc, "vpc", Method.PUT);
+            return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, updateVpc, "vpc", Method.Put);
         }
 
         /// <summary>
@@ -68,9 +68,9 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<Vpc> PartialUpdate(string vpcId, Models.Requests.UpdateVpc updateVpc) {
             var parameters = new List<Parameter> {
-                new Parameter("id", vpcId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", vpcId)
             };
-            return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, updateVpc, "vpc", Method.PATCH);
+            return _connection.ExecuteRequest<Vpc>("vpcs/{id}", parameters, updateVpc, "vpc", Method.Patch);
         }
 
         /// <summary>
@@ -79,10 +79,10 @@ namespace DigitalOcean.API.Clients {
         /// </summary>
         public Task<IReadOnlyList<VpcMember>> ListMembers(string vpcId, string resourceType = null) {
             var parameters = new List<Parameter> {
-                new Parameter("id", vpcId, ParameterType.UrlSegment)
+                new UrlSegmentParameter ("id", vpcId)
             };
             if (!String.IsNullOrEmpty(resourceType)) {
-                parameters.Add(new Parameter("resource_type", resourceType, ParameterType.QueryString));
+                parameters.Add(new QueryParameter("resource_type", resourceType));
             }
             return _connection.GetPaginated<VpcMember>("vpcs/{id}/members", parameters, "members");
         }

--- a/DigitalOcean.API/DigitalOcean.API.csproj
+++ b/DigitalOcean.API/DigitalOcean.API.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>vevix</Authors>
     <Version>5.2.0</Version>
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
 </Project>

--- a/DigitalOcean.API/DigitalOcean.API.csproj
+++ b/DigitalOcean.API/DigitalOcean.API.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>vevix</Authors>
     <Version>5.2.0</Version>
@@ -23,5 +23,6 @@
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />
   </ItemGroup>
 </Project>

--- a/DigitalOcean.API/DigitalOceanClient.cs
+++ b/DigitalOcean.API/DigitalOceanClient.cs
@@ -8,9 +8,10 @@ namespace DigitalOcean.API {
         private readonly IConnection _connection;
 
         public DigitalOceanClient(string token) {
-            var client = new RestClient(DigitalOceanApiUrl) {
+            var restClientOptions = new RestClientOptions(DigitalOceanApiUrl) {
                 UserAgent = "digitalocean-api-dotnet"
             };
+            var client = new RestClient(restClientOptions);
             client.AddDefaultHeader("Authorization", string.Format("Bearer {0}", token));
 
             _connection = new Connection(client);

--- a/DigitalOcean.API/DigitalOceanClient.cs
+++ b/DigitalOcean.API/DigitalOceanClient.cs
@@ -9,7 +9,8 @@ namespace DigitalOcean.API {
 
         public DigitalOceanClient(string token) {
             var restClientOptions = new RestClientOptions(DigitalOceanApiUrl) {
-                UserAgent = "digitalocean-api-dotnet"
+                UserAgent = "digitalocean-api-dotnet",
+                DisableCharset = true
             };
             var client = new RestClient(restClientOptions);
             client.AddDefaultHeader("Authorization", string.Format("Bearer {0}", token));

--- a/DigitalOcean.API/DigitalOceanClient.cs
+++ b/DigitalOcean.API/DigitalOceanClient.cs
@@ -1,6 +1,7 @@
 using DigitalOcean.API.Clients;
 using DigitalOcean.API.Http;
 using RestSharp;
+using RestSharp.Serializers.NewtonsoftJson;
 
 namespace DigitalOcean.API {
     public class DigitalOceanClient : IDigitalOceanClient {
@@ -12,7 +13,8 @@ namespace DigitalOcean.API {
                 UserAgent = "digitalocean-api-dotnet",
                 DisableCharset = true
             };
-            var client = new RestClient(restClientOptions);
+            var client = new RestClient(restClientOptions,
+                configureSerialization: s => s.UseNewtonsoftJson());
             client.AddDefaultHeader("Authorization", string.Format("Bearer {0}", token));
 
             _connection = new Connection(client);

--- a/DigitalOcean.API/Exceptions/ApiException.cs
+++ b/DigitalOcean.API/Exceptions/ApiException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using DigitalOcean.API.Models.Responses;
@@ -25,14 +25,14 @@ namespace DigitalOcean.API.Exceptions {
         }
 
         private readonly Error _internalErrorResponse;
-        private Func<IRestResponse, Error> _p;
+        private Func<RestResponse, Error> _p;
 
         public ApiException(HttpStatusCode statusCode, Error errorResponse) {
             StatusCode = statusCode;
             _internalErrorResponse = errorResponse;
         }
 
-        public ApiException(HttpStatusCode statusCode, Func<IRestResponse, Error> p) {
+        public ApiException(HttpStatusCode statusCode, Func<RestResponse, Error> p) {
             StatusCode = statusCode;
             _p = p;
         }

--- a/DigitalOcean.API/Extensions/RestSharpExtensions.cs
+++ b/DigitalOcean.API/Extensions/RestSharpExtensions.cs
@@ -3,13 +3,11 @@ using System.Threading.Tasks;
 using DigitalOcean.API.Exceptions;
 using DigitalOcean.API.Models.Responses;
 using RestSharp;
-// using RestSharp.Serialization.Json;
-using RestSharp.Extensions;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Text.Json;
 using DigitalOcean.API.Helpers;
-using System.Net;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 
 namespace DigitalOcean.API.Extensions {
     public static class RestSharpExtensions {
@@ -36,7 +34,7 @@ namespace DigitalOcean.API.Extensions {
             }
 
             if (response.ResponseStatus != ResponseStatus.Completed) {
-                throw new WebException(response.ErrorException.Message);
+                response.ThrowIfError();
             }
 
             if ((int)response.StatusCode >= 400) {
@@ -52,7 +50,8 @@ namespace DigitalOcean.API.Extensions {
 
         public static T Deserialize<T>(this RestResponse response) {
             response.Request.OnBeforeDeserialization(response);
-            return JsonDeserializationHelper.DeserializeWithRootElementName<T>(response.Content, response.Request.RootElement);
+            var parsedJson = (JObject)JsonConvert.DeserializeObject(response.Content);
+            return JsonDeserializationHelper.DeserializeWithRootElementName<T>(parsedJson, response.Request.RootElement);
         }
     }
 }

--- a/DigitalOcean.API/Helpers/JsonDeserializationHelper.cs
+++ b/DigitalOcean.API/Helpers/JsonDeserializationHelper.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json.Linq;
+using RestSharp;
+
+namespace DigitalOcean.API.Helpers {
+    internal class JsonDeserializationHelper {
+
+        public static T DeserializeWithRootElementName<T>(string json, string rootElement) {
+            var parsedJson = JObject.Parse(json);
+            if (rootElement == null || !parsedJson.ContainsKey(rootElement))
+                return (T)parsedJson.ToObject(typeof(T));
+
+            return (T)parsedJson[rootElement].ToObject(typeof(T));
+        }
+    }
+}

--- a/DigitalOcean.API/Helpers/JsonDeserializationHelper.cs
+++ b/DigitalOcean.API/Helpers/JsonDeserializationHelper.cs
@@ -1,15 +1,29 @@
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using RestSharp;
+using Newtonsoft.Json.Serialization;
+using System;
 
 namespace DigitalOcean.API.Helpers {
     internal class JsonDeserializationHelper {
 
-        public static T DeserializeWithRootElementName<T>(string json, string rootElement) {
-            var parsedJson = JObject.Parse(json);
-            if (rootElement == null || !parsedJson.ContainsKey(rootElement))
-                return (T)parsedJson.ToObject(typeof(T));
+        public static JsonSerializerSettings DeserializerSettings { get; private set; } = new JsonSerializerSettings() {
+            DateFormatString = "yyyy-MM-ddTHH:mm:ssZ",
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new DefaultContractResolver() { NamingStrategy = new SnakeCaseNamingStrategy() }
+        };
 
-            return (T)parsedJson[rootElement].ToObject(typeof(T));
+        public static JsonSerializer Deserializer { get; private set; } = JsonSerializer.Create(DeserializerSettings);
+
+        public static T DeserializeWithRootElementName<T>(JObject parsedJson, string rootElement, JsonSerializer deserializer = null) {
+            if (parsedJson == null) throw new ArgumentNullException(nameof(parsedJson));
+
+            var desrializerObj = deserializer ?? Deserializer;
+            if (rootElement == null)
+                return parsedJson.ToObject<T>(desrializerObj);
+            else if (!parsedJson.ContainsKey(rootElement))
+                return (T)Activator.CreateInstance(typeof(T));
+
+            return parsedJson[rootElement].ToObject<T>(desrializerObj);
         }
     }
 }

--- a/DigitalOcean.API/Helpers/JsonNetSerializer.cs
+++ b/DigitalOcean.API/Helpers/JsonNetSerializer.cs
@@ -1,5 +1,6 @@
-﻿using System.IO;
+using System.IO;
 using Newtonsoft.Json;
+using RestSharp;
 using RestSharp.Serializers;
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 
@@ -8,7 +9,7 @@ namespace DigitalOcean.API.Helpers {
         private readonly JsonSerializer _serializer;
 
         public JsonNetSerializer() {
-            ContentType = "application/json";
+            ContentType = ContentType.Json;
             _serializer = new JsonSerializer {
                 MissingMemberHandling = MissingMemberHandling.Ignore,
                 NullValueHandling = NullValueHandling.Include,
@@ -33,7 +34,7 @@ namespace DigitalOcean.API.Helpers {
         public string RootElement { get; set; }
         public string Namespace { get; set; }
         public string DateFormat { get; set; }
-        public string ContentType { get; set; }
+        public ContentType ContentType { get; set; }
 
         #endregion
     }

--- a/DigitalOcean.API/Http/IConnection.cs
+++ b/DigitalOcean.API/Http/IConnection.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using RestSharp;
 
@@ -7,10 +7,10 @@ namespace DigitalOcean.API.Http {
         IRestClient Client { get; }
         IRateLimit Rates { get; }
 
-        Task<IRestResponse> ExecuteRaw(string endpoint, IList<Parameter> parameters, object data = null, Method method = Method.GET);
+        Task<RestResponse> ExecuteRaw(string endpoint, IList<Parameter> parameters, object data = null, Method method = Method.Get);
 
         Task<T> ExecuteRequest<T>(string endpoint, IList<Parameter> parameters,
-            object data = null, string expectedRoot = null, Method method = Method.GET) where T : new();
+            object data = null, string expectedRoot = null, Method method = Method.Get) where T : new();
 
         Task<IReadOnlyList<T>> GetPaginated<T>(string endpoint, IList<Parameter> parameters,
             string expectedRoot = null) where T : new();

--- a/DigitalOcean.API/Http/RateLimit.cs
+++ b/DigitalOcean.API/Http/RateLimit.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using RestSharp;
 
 namespace DigitalOcean.API.Http {
     public class RateLimit : IRateLimit {
-        public RateLimit(IList<Parameter> headers) {
+        public RateLimit(IReadOnlyCollection<HeaderParameter> headers) {
             Limit = GetHeaderValue(headers, "Ratelimit-Limit");
             Remaining = GetHeaderValue(headers, "Ratelimit-Remaining");
             Reset = GetHeaderValue(headers, "Ratelimit-Reset");
@@ -29,7 +29,7 @@ namespace DigitalOcean.API.Http {
 
         #endregion
 
-        private static int GetHeaderValue(IEnumerable<Parameter> headers, string name) {
+        private static int GetHeaderValue(IEnumerable<HeaderParameter> headers, string name) {
             var header = headers.FirstOrDefault(x => x.Name == name);
             int value;
             return header != null && int.TryParse(header.Value.ToString(), out value) ? value : 0;


### PR DESCRIPTION
RestSharp made quite a few breaking changes to their library (unsure at what version exactly). Running into some dependency problems with other libraries wanting more recent versions of RestSharp. So these are the changes necessary to use most recent releases.

You'll see the majority of changes are simple method/verb types, and parameter type changes.

The real "significant" changes are in `Http.Connection` and `Extensions.RestSharpExtensions`, where JSON (de)serialization is occurring. RestSharp was actually using its own hybrid JSON (de)serializer. It **was not** using Newtonsoft internally (what I originally thought was happening, but unfortunately not). With their updates they abstracted out all serialization completely and deprecated their hybrid serialization in favor of dependencies to handle that. So they have components to choose between using Newtonsoft or System.Text.Json now.

We chose to use Newtonsoft as simplest to make a mostly 1:1 conversion. As Newtonsoft's serializer is quite forgiving, compared to System.Text.Json. Switching to .NET's System.Text.Json would likely be preferable in long run, but would require significantly more testing and checks to assure all is ok. Also this library was already partially using Newtonsoft as well (yet to make the System.Text.Json plunge).

So the major changes controlling (de)serialization were in those classes (`Http.Connection` and `Extensions.RestSharpExtensions`). Attempting to keep the current design/flow as much as possible.

We are primarily only using the client for Droplets, so primarily have only tested against those endpoints. Assuming all others should be ok as well. All Unit Tests still pass.